### PR TITLE
Enable cors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ TYPEORM_USERNAME=
 TYPEORM_PASSWORD=
 TYPEORM_DATABASE=
 TYPEORM_PORT=
+
+# Cors settings
+CORS_ORIGIN=    # set to either a defined host or use * in development

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,10 @@ import { ValidationPipe } from '@nestjs/common';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const port = process.env.PORT || 3000;
+  app.enableCors({
+    origin: process.env.CORS_ORIGIN,
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+  });
 
   // Setup global pipe to enforce type validation on all routes
   app.useGlobalPipes(


### PR DESCRIPTION
This enables CORS for the API.

Note that you'll have to set the env variable accordingly (or just use * :D).

Required for https://github.com/gipfeli-io/gipfeli-frontend/issues/27