### PR TITLE
Add handling for not found, update strategy to not expose existing users when a user is not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 COPY package.json .
 
+COPY package-lock.json .
+
 RUN npm install
 
 RUN npm i -g typeorm ts-node #check if this is really needed

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -8,6 +8,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { jwtConstants } from './common/constants';
 import { HashService } from '../utils/hash.service';
 import * as bcrypt from 'bcrypt';
+import { NotFoundException } from '@nestjs/common';
 
 let result: UserDto;
 const userConfig = {
@@ -81,12 +82,14 @@ describe('AuthService', () => {
       expect(await service.validateUser(username, password)).toEqual(null);
     });
 
-    it('should return null when username does not match', async () => {
+    it('throws NotFoundException if user and password do not match or do not exist', async () => {
       result = null; // reset result to null so that user service mock returns null
       const username = 'peter@gipfeli.io';
       const password = '5678';
 
-      expect(await service.validateUser(username, password)).toEqual(null);
+      const call = async () => await service.validateUser(username, password);
+
+      await expect(call).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/auth/strategies/local.strategy.ts
+++ b/src/auth/strategies/local.strategy.ts
@@ -1,6 +1,6 @@
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { AuthService } from '../auth.service';
 
 @Injectable()
@@ -12,7 +12,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   async validate(username: string, password: string): Promise<any> {
     const user = await this.authService.validateUser(username, password);
     if (!user) {
-      throw new UnauthorizedException();
+      throw new NotFoundException();
     }
     return user;
   }

--- a/src/tour/tour.controller.spec.ts
+++ b/src/tour/tour.controller.spec.ts
@@ -9,7 +9,7 @@ import {
   tourDataMockForPaul,
 } from './mocks/tour.data.mock';
 import { tourRepositoryMock } from './mocks/tour.repository.mock';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { TourDto } from './dto/tour';
 
 const resultsForFranz = tourDataMockForFranz;
@@ -68,13 +68,14 @@ describe('TourController', () => {
       expect(controllerSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('does not return a tour that belongs to another user', async () => {
+    it('does not return a tour that belongs to another user and throws a NotFoundException', async () => {
       const controllerSpy = jest.spyOn(tourController, 'findOne');
-      const result = await tourController.findOne(resultsForFranz[0].id, {
-        id: resultsForPaul[0].user.id,
-      } as UserDto);
+      const result = async () =>
+        await tourController.findOne(resultsForFranz[0].id, {
+          id: resultsForPaul[0].user.id,
+        } as UserDto);
 
-      expect(result).not.toBeDefined();
+      await expect(result).rejects.toThrow(NotFoundException);
       expect(controllerSpy).toHaveBeenCalledTimes(1);
     });
   });
@@ -95,18 +96,18 @@ describe('TourController', () => {
       expect(controllerSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('raises an exception if trying to update non existing tour', async () => {
+    it('raises NotFoundException if trying to update non existing tour', async () => {
       const controllerSpy = jest.spyOn(tourController, 'update');
       const result = async () =>
         await tourController.update('does-not-exist', { name: 'updated' }, {
           id: resultsForPaul[0].user.id,
         } as UserDto);
 
-      await expect(result).rejects.toThrow(BadRequestException);
+      await expect(result).rejects.toThrow(NotFoundException);
       expect(controllerSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('raises an exception if trying to update a tour of another user', async () => {
+    it('raises NotFoundException if trying to update a tour of another user', async () => {
       const controllerSpy = jest.spyOn(tourController, 'update');
       const result = async () =>
         await tourController.update(
@@ -117,7 +118,7 @@ describe('TourController', () => {
           } as UserDto,
         );
 
-      await expect(result).rejects.toThrow(BadRequestException);
+      await expect(result).rejects.toThrow(NotFoundException);
       expect(controllerSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -134,25 +135,25 @@ describe('TourController', () => {
         expect(controllerSpy).toHaveBeenCalledTimes(1);
       });
 
-      it('raises an exception if trying to update non existing tour', async () => {
+      it('raises NotFoundException if trying to update non existing tour', async () => {
         const controllerSpy = jest.spyOn(tourController, 'remove');
         const result = async () =>
           await tourController.remove(resultsForFranz[0].id, {
             id: 'does-not-exist',
           } as UserDto);
 
-        await expect(result).rejects.toThrow(BadRequestException);
+        await expect(result).rejects.toThrow(NotFoundException);
         expect(controllerSpy).toHaveBeenCalledTimes(1);
       });
 
-      it('raises an exception if trying to update a tour of another user', async () => {
+      it('raises NotFoundException if trying to update a tour of another user', async () => {
         const controllerSpy = jest.spyOn(tourController, 'remove');
         const result = async () =>
           await tourController.remove(resultsForFranz[0].id, {
             id: resultsForPaul[0].user.id,
           } as UserDto);
 
-        await expect(result).rejects.toThrow(BadRequestException);
+        await expect(result).rejects.toThrow(NotFoundException);
         expect(controllerSpy).toHaveBeenCalledTimes(1);
       });
     });

--- a/src/tour/tour.service.spec.ts
+++ b/src/tour/tour.service.spec.ts
@@ -4,7 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { TourService } from './tour.service';
 import { Tour } from './entities/tour.entity';
 import { TourDto } from './dto/tour';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { tourRepositoryMock } from './mocks/tour.repository.mock';
 import {
   tourDataMockForFranz,
@@ -51,12 +51,13 @@ describe('TourService', () => {
       expect(result.id).toEqual(resultsForPaul[0].id);
     });
 
-    it('does not return a tour that belongs to another user', async () => {
-      const result = await service.findOne(resultsForFranz[0].id, {
-        id: resultsForPaul[0].user.id,
-      } as UserDto);
+    it('does not return a tour that belongs to another user and throws NotFoundException', async () => {
+      const call = async () =>
+        await service.findOne(resultsForFranz[0].id, {
+          id: resultsForPaul[0].user.id,
+        } as UserDto);
 
-      expect(result).not.toBeDefined();
+      await expect(call).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -74,22 +75,22 @@ describe('TourService', () => {
       expect(result.id).toEqual(resultsForPaul[0].id);
     });
 
-    it('raises an exception if trying to update non existing tour', async () => {
+    it('raises NotFoundException if trying to update non existing tour', async () => {
       const result = async () =>
         await service.update('does-not-exist', { name: 'updated' }, {
           id: resultsForPaul[0].user.id,
         } as UserDto);
 
-      await expect(result).rejects.toThrow(BadRequestException);
+      await expect(result).rejects.toThrow(NotFoundException);
     });
 
-    it('raises an exception if trying to update a tour of another user', async () => {
+    it('raises NotFoundException if trying to update a tour of another user', async () => {
       const result = async () =>
         await service.update(resultsForFranz[0].id, { name: 'updated' }, {
           id: resultsForPaul[0].user.id,
         } as UserDto);
 
-      await expect(result).rejects.toThrow(BadRequestException);
+      await expect(result).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -104,22 +105,22 @@ describe('TourService', () => {
       await expect(result).resolves.not.toThrow();
     });
 
-    it('raises an exception if trying to update non existing tour', async () => {
+    it('raises NotFoundException if trying to update non existing tour', async () => {
       const result = async () =>
         await service.remove(resultsForFranz[0].id, {
           id: 'does-not-exist',
         } as UserDto);
 
-      await expect(result).rejects.toThrow(BadRequestException);
+      await expect(result).rejects.toThrow(NotFoundException);
     });
 
-    it('raises an exception if trying to update a tour of another user', async () => {
+    it('raises NotFoundException if trying to update a tour of another user', async () => {
       const result = async () =>
         await service.remove(resultsForFranz[0].id, {
           id: resultsForPaul[0].user.id,
         } as UserDto);
 
-      await expect(result).rejects.toThrow(BadRequestException);
+      await expect(result).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/src/tour/tour.service.ts
+++ b/src/tour/tour.service.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Tour } from './entities/tour.entity';
@@ -19,18 +23,23 @@ export class TourService {
   }
 
   findAll(user: UserDto): Promise<TourDto[]> {
-    // todo: async not required?
     return this.tourRepository.find({
       where: { user },
       relations: ['user'],
     });
   }
 
-  findOne(id: string, user: UserDto): Promise<TourDto> {
-    return this.tourRepository.findOne(id, {
+  async findOne(id: string, user: UserDto): Promise<TourDto> {
+    const result = await this.tourRepository.findOne(id, {
       where: { user },
       relations: ['user'],
     });
+
+    if (!result) {
+      throw new NotFoundException();
+    }
+
+    return result;
   }
 
   async update(
@@ -44,9 +53,7 @@ export class TourService {
     );
 
     if (updateResult.affected === 0) {
-      throw new BadRequestException(
-        'Todo: handle this and all other errors :)',
-      );
+      throw new NotFoundException();
     }
 
     return await this.tourRepository.findOne(id, { relations: ['user'] });
@@ -56,9 +63,7 @@ export class TourService {
     const deleteResult = await this.tourRepository.delete({ id, user });
 
     if (deleteResult.affected === 0) {
-      throw new BadRequestException(
-        'Todo: handle this and all other errors :)',
-      );
+      throw new NotFoundException();
     }
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { Repository } from 'typeorm';
@@ -16,6 +16,14 @@ export class UserService {
   }
 
   async findOne(username: string): Promise<UserDto> {
-    return this.userRepository.findOne({ where: [{ username: username }] });
+    const user = await this.userRepository.findOne({
+      where: [{ username: username }],
+    });
+
+    if (user) {
+      return user;
+    }
+
+    throw new NotFoundException();
   }
 }


### PR DESCRIPTION
This PR is related to https://github.com/gipfeli-io/gipfeli-frontend/pull/43 and adds some exceptions if items cannot be found. It also updates our strategy to not throw an unauthorized message, because that would make us vulnerable to user enumeration attacks.