### PR TITLE
Fix/more sonarcloud tunings

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,6 +1,7 @@
 name: Build and Deploy solution
 
 on:
+  # Trigger only on either a push OR on a pull request
   push:
     branches:
       - master

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,7 +1,14 @@
 name: Build and Deploy solution
 
 on:
-  - push
+  push:
+    branches:
+      - master
+      - stage
+  pull_request:
+    branches:
+      - master
+      - stage
 
 jobs:
   test-and-build:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,15 +1,7 @@
 name: Build and Deploy solution
 
 on:
-  # Trigger only on either a push OR on a pull request
-  push:
-    branches:
-      - master
-      - stage
-  pull_request:
-    branches:
-      - master
-      - stage
+  - push
 
 jobs:
   test-and-build:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,4 @@ sonar.projectKey=gipfeli-io_gipfeli-api
 sonar.organization=gipfeli-io
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sources=src
-sonar.exclusions=*.spec.ts
+sonar.coverage.exclusions=**/*.spec.ts,**/database-config.ts,**/*.module.ts


### PR DESCRIPTION
Exludes the test files and some others.

I also tried to fix the missing SonarCloud comment - but that one only triggers if you use `on: pull_request` in the github action. Addin that triggers the pipeline twice, so we'd have to split our github actions and use multiple jobs.