### PR TITLE
Feature/remove user object details

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -100,8 +100,14 @@ describe('AuthService', () => {
       const { unhashedPassword, email } = userConfig;
       const [_, user] = getUserDtoAndUserObject(true);
       const mockSession = 'x-x-x-x';
-      userRepositoryMock.findOne.mockReturnValue(user);
       sessionRepositoryMock.create.mockReturnValue(mockSession);
+      userRepositoryMock.createQueryBuilder.mockImplementation(() => {
+        return {
+          addSelect: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          getOne: jest.fn().mockReturnValueOnce(user),
+        };
+      });
 
       const expected: UserIdentifier = {
         sub: user.id,
@@ -117,7 +123,13 @@ describe('AuthService', () => {
       const { email } = userConfig;
       const password = 'this-is-a-wrong-password';
       const [_, user] = getUserDtoAndUserObject(true);
-      userRepositoryMock.findOne.mockReturnValue(user);
+      userRepositoryMock.createQueryBuilder.mockImplementation(() => {
+        return {
+          addSelect: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          getOne: jest.fn().mockReturnValueOnce(user),
+        };
+      });
 
       expect(await authService.validateUser(email, password)).toEqual(null);
     });
@@ -125,7 +137,13 @@ describe('AuthService', () => {
     it('throws NotFoundException if user and password do not match or do not exist', async () => {
       const email = 'peter@gipfeli.io';
       const password = '5678';
-      userRepositoryMock.findOne.mockReturnValue(null);
+      userRepositoryMock.createQueryBuilder.mockImplementation(() => {
+        return {
+          addSelect: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          getOne: jest.fn().mockReturnValueOnce(null),
+        };
+      });
 
       const call = async () => await authService.validateUser(email, password);
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -35,7 +35,7 @@ export class AuthService {
     email: string,
     password: string,
   ): Promise<UserIdentifier | null> {
-    const user = await this.userService.findOne(email);
+    const user = await this.userService.findOneForAuth(email);
     const passwordsMatch = await this.hashService.compare(
       password,
       user.password,

--- a/src/tour/tour.service.spec.ts
+++ b/src/tour/tour.service.spec.ts
@@ -69,7 +69,6 @@ describe('TourService', () => {
       const result = await tourService.findAll(mockUser);
 
       const expectedConditions: FindManyOptions<Tour> = {
-        relations: ['user'],
         where: { user: mockUser },
       };
       expect(tourRepositoryMock.find).toHaveBeenCalledTimes(1);
@@ -84,7 +83,7 @@ describe('TourService', () => {
       const result = await tourService.findOne(mockId, mockUser);
 
       const expectedConditions: FindOneOptions<Tour> = {
-        relations: ['user', 'images'],
+        relations: ['images'],
         where: { user: mockUser },
       };
       expect(tourRepositoryMock.findOne).toHaveBeenCalledTimes(1);

--- a/src/tour/tour.service.ts
+++ b/src/tour/tour.service.ts
@@ -37,14 +37,13 @@ export class TourService {
   findAll(user: AuthenticatedUserDto): Promise<TourDto[]> {
     return this.tourRepository.find({
       where: { user },
-      relations: ['user'],
     });
   }
 
   async findOne(id: string, user: AuthenticatedUserDto): Promise<TourDto> {
     const result = await this.tourRepository.findOne(id, {
       where: { user },
-      relations: ['user', 'images'],
+      relations: ['images'],
     });
 
     if (!result) {

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -29,7 +29,7 @@ export class User {
   @Column()
   email: string;
 
-  @Column()
+  @Column({ select: false })
   password: string;
 
   @CreateDateColumn()

--- a/src/utils/mock-utils/repository-mock.factory.ts
+++ b/src/utils/mock-utils/repository-mock.factory.ts
@@ -22,6 +22,8 @@ const repositoryMockFactory: () => RepositoryMockType<Repository<any>> =
       innerJoinAndSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       getOneOrFail: jest.fn((entity) => entity),
+      addSelect: jest.fn().mockReturnThis(),
+      getOne: jest.fn((entity) => entity),
     })),
   }));
 


### PR DESCRIPTION
Closes #31. The password is now also excluded per default and has to be selected explicitly. This way, it should never be exposed, unless you actually screw up.

However, we have a more fundamental issue: Our services actually do not return a DTO, but the entities themselves. This only works because of the type overlap between the entities and the DTOs, but it becomes apparent when we use class-transformer decorators. If we eclude the password from the `UserDto`, our services will still happily return the password, because internally, they respond with a `User` object.

A "quick" fix would be a "entity-to-dto" helper:
![image](https://user-images.githubusercontent.com/16555423/180177819-5eb8838e-b653-4732-bef1-37bd32fd9ba1.png)

However, that would have to be used on EVERY single service response. Another alternative would be to return the entities (and not the DTOs), and use class-transformer decorators on them.

Let's discuss this tonight.