### PR TITLE
Fix broken migration

### DIFF
--- a/migrations/1654957407315-SetCurrentUsersToActive.ts
+++ b/migrations/1654957407315-SetCurrentUsersToActive.ts
@@ -10,22 +10,14 @@ export class SetCurrentUsersToActive1654957407315
   implements MigrationInterface
 {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    const users = await queryRunner.manager.find(User);
-
-    for (const user of users) {
-      user.isActive = true;
-    }
-
-    await queryRunner.manager.save(users);
+    const schema = await queryRunner.getCurrentSchema();
+    const table = queryRunner.manager.getRepository(User).metadata.tableName;
+    await queryRunner.query(`UPDATE ${schema}.${table} SET "isActive" = TRUE`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    const users = await queryRunner.manager.find(User);
-
-    for (const user of users) {
-      user.isActive = false;
-    }
-
-    await queryRunner.manager.save(users);
+    const schema = await queryRunner.getCurrentSchema();
+    const table = queryRunner.manager.getRepository(User).metadata.tableName;
+    await queryRunner.query(`UPDATE ${schema}.${table} SET "isActive" = FALSE`);
   }
 }


### PR DESCRIPTION
I was playing around with our docker setup for Tobi, and our migrations failed.

The reason was that I erroneously (!!!! :D) used the `User` entity in the migration, but our entity has evolved since this migration was applied. This led to an error because some fields the `User` has do not exist at that time.

Lesson learned: always use plain SQL in migrations :D