### PR TITLE
Add validation pipe

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,5 +2,5 @@ sonar.projectKey=gipfeli-io_gipfeli-api
 sonar.organization=gipfeli-io
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sources=src
-sonar.coverage.exclusions=**/main.ts,**/*.spec.ts,**/config/*.config.ts,**/*.module.ts,**/*.entity.ts,**/*.strategy.ts,**/dto/*.ts
+sonar.coverage.exclusions=**/main.ts,**/shared/validation/**.ts,**/shared/interceptors/**.ts,**/*.spec.ts,**/config/*.config.ts,**/*.module.ts,**/*.entity.ts,**/*.strategy.ts,**/dto/*.ts
 sonar.cpd.exclusions=**/*.spec.ts

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -255,6 +255,7 @@ describe('AuthController', () => {
         password: 'x-x-x',
         token: 'mock-token',
         userId: 'mock-user-id',
+        passwordConfirmation: 'x-x-x',
       };
 
       await authController.passwordResetSet(setNewPasswordDto);

--- a/src/auth/dto/auth.ts
+++ b/src/auth/dto/auth.ts
@@ -1,5 +1,7 @@
 import { IsEmail, IsNotEmpty, IsString, IsUUID } from 'class-validator';
 import { UserDto } from '../../user/dto/user';
+import { MatchesOtherProperty } from '../../user/dto/validators/matches-other-property.decorator';
+import { IsStrongPassword } from '../../user/dto/validators/is-strong-password.decorator';
 
 export class TokenDto {
   accessToken: string;
@@ -28,5 +30,16 @@ export class SetNewPasswordDto {
 
   @IsString()
   @IsNotEmpty()
+  @MatchesOtherProperty('passwordConfirmation', {
+    message: 'Passwords do not match',
+  })
+  @IsStrongPassword()
   password: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MatchesOtherProperty('password', {
+    message: 'Passwords do not match',
+  })
+  passwordConfirmation: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import { SentryInterceptor } from './shared/interceptors/SentryInterceptor';
 import { ConfigService } from '@nestjs/config';
+import GroupedExceptionFactory from './shared/validation/GroupedExceptionFactory';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -18,6 +19,7 @@ async function bootstrap() {
   // Setup global pipe to enforce type validation on all routes
   app.useGlobalPipes(
     new ValidationPipe({
+      exceptionFactory: GroupedExceptionFactory,
       validationError: { target: true, value: true },
       whitelist: true,
       forbidNonWhitelisted: true,

--- a/src/shared/validation/GroupedExceptionFactory.ts
+++ b/src/shared/validation/GroupedExceptionFactory.ts
@@ -1,0 +1,13 @@
+import { BadRequestException, ValidationError } from '@nestjs/common';
+
+const GroupedExceptionFactory = (errors: ValidationError[]) => {
+  const messages = errors.map((value) => ({
+    errors: value.constraints ? Object.values(value.constraints) : [],
+    property: value.property,
+    value: value.value,
+  }));
+
+  return new BadRequestException(messages);
+};
+
+export default GroupedExceptionFactory;

--- a/src/user/dto/user.ts
+++ b/src/user/dto/user.ts
@@ -1,6 +1,7 @@
 import { OmitType, PickType } from '@nestjs/mapped-types';
 import { IsEmail, IsEnum, IsNotEmpty, IsString, IsUUID } from 'class-validator';
 import { UserRole } from '../entities/user.entity';
+import { MatchesOtherProperty } from './validators/matches-other-property.decorator';
 
 // todo: rework our userdto to properly type it - the role and password are not used everywhere, etc.
 export class UserDto {
@@ -38,7 +39,25 @@ export class AuthenticatedUserDto extends PickType(UserDto, [
   'role',
 ] as const) {}
 
-export class CreateUserDto extends OmitType(UserDto, ['id', 'role'] as const) {}
+export class CreateUserDto extends OmitType(UserDto, [
+  'id',
+  'role',
+  'password',
+] as const) {
+  @IsString()
+  @IsNotEmpty()
+  @MatchesOtherProperty('passwordConfirmation', {
+    message: 'Passwords do not match',
+  })
+  password: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MatchesOtherProperty('password', {
+    message: 'Passwords do not match',
+  })
+  passwordConfirmation: string;
+}
 
 export class UserCreatedDto {
   user: UserDto;

--- a/src/user/dto/user.ts
+++ b/src/user/dto/user.ts
@@ -2,6 +2,7 @@ import { OmitType, PickType } from '@nestjs/mapped-types';
 import { IsEmail, IsEnum, IsNotEmpty, IsString, IsUUID } from 'class-validator';
 import { UserRole } from '../entities/user.entity';
 import { MatchesOtherProperty } from './validators/matches-other-property.decorator';
+import { IsStrongPassword } from './validators/is-strong-password.decorator';
 
 export class UserDto {
   @IsUUID()
@@ -54,6 +55,7 @@ export class CreateUserDto extends OmitType(UserDto, ['id', 'role'] as const) {
   @MatchesOtherProperty('passwordConfirmation', {
     message: 'Passwords do not match',
   })
+  @IsStrongPassword()
   password: string;
 
   @IsString()

--- a/src/user/dto/user.ts
+++ b/src/user/dto/user.ts
@@ -3,7 +3,6 @@ import { IsEmail, IsEnum, IsNotEmpty, IsString, IsUUID } from 'class-validator';
 import { UserRole } from '../entities/user.entity';
 import { MatchesOtherProperty } from './validators/matches-other-property.decorator';
 
-// todo: rework our userdto to properly type it - the role and password are not used everywhere, etc.
 export class UserDto {
   @IsUUID()
   @IsNotEmpty()
@@ -21,29 +20,35 @@ export class UserDto {
   @IsNotEmpty()
   email: string;
 
-  @IsString()
-  @IsNotEmpty()
-  password: string;
-
   @IsEnum(UserRole)
+  @IsNotEmpty()
   role: UserRole;
 }
 
 /**
- * This DTO is created by the @User decorator and consists of the user's ID and
- * email.
+ * Used in auth checks, contains email, id, role and password.
  */
-export class AuthenticatedUserDto extends PickType(UserDto, [
+export class UserWithPasswordDto extends PickType(UserDto, [
+  'id',
+  'email',
+  'role',
+]) {
+  @IsString()
+  @IsNotEmpty()
+  password: string;
+}
+
+/**
+ * This DTO is created by the @User decorator and consists of the user's ID and
+ * email and role.
+ */
+export class AuthenticatedUserDto extends PickType(UserWithPasswordDto, [
   'id',
   'email',
   'role',
 ] as const) {}
 
-export class CreateUserDto extends OmitType(UserDto, [
-  'id',
-  'role',
-  'password',
-] as const) {
+export class CreateUserDto extends OmitType(UserDto, ['id', 'role'] as const) {
   @IsString()
   @IsNotEmpty()
   @MatchesOtherProperty('passwordConfirmation', {

--- a/src/user/dto/validators/is-strong-password.decorator.spec.ts
+++ b/src/user/dto/validators/is-strong-password.decorator.spec.ts
@@ -1,0 +1,48 @@
+import { validate } from 'class-validator';
+import { IsStrongPassword } from './is-strong-password.decorator';
+
+class TestObject {
+  @IsStrongPassword()
+  password: string;
+}
+
+describe('IsStrongPassword Decorator', () => {
+  let testObject: TestObject;
+
+  beforeEach(() => (testObject = new TestObject()));
+
+  it('marks strong password as valid', async () => {
+    testObject.password = 'Aa$aaaaa';
+
+    const errors = await validate(testObject);
+    expect(errors.length).toBe(0);
+  });
+
+  it('password with less than 8 chars is invalid', async () => {
+    testObject.password = 'Aa$aaaa';
+
+    const errors = await validate(testObject);
+    expect(errors.length).toBe(1);
+  });
+
+  it('password without upper case letter is invalid', async () => {
+    testObject.password = 'aa$aaaaa';
+
+    const errors = await validate(testObject);
+    expect(errors.length).toBe(1);
+  });
+
+  it('password without lower case letter is invalid', async () => {
+    testObject.password = 'AA$AAAAA';
+
+    const errors = await validate(testObject);
+    expect(errors.length).toBe(1);
+  });
+
+  it('password without special chars is invalid', async () => {
+    testObject.password = 'AAaAAAAA';
+
+    const errors = await validate(testObject);
+    expect(errors.length).toBe(1);
+  });
+});

--- a/src/user/dto/validators/is-strong-password.decorator.ts
+++ b/src/user/dto/validators/is-strong-password.decorator.ts
@@ -1,0 +1,38 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+const PASSWORD_STRENGTH =
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*[.*[!@#$%^&*()\-__+.]).{8,}$/;
+
+@ValidatorConstraint({ async: true })
+class IsStrongPasswordConstraint implements ValidatorConstraintInterface {
+  defaultMessage(validationArguments?: ValidationArguments): string {
+    return `${validationArguments.property} must contain at lest 1 upper and 1 lower case letter, must be at least 8 characters long and contain at least 1 special character.`;
+  }
+
+  validate(password: string, _args: ValidationArguments) {
+    return PASSWORD_STRENGTH.test(password);
+  }
+}
+
+/**
+ * Check if the password is strong enough
+ * @param validationOptions
+ * @constructor
+ */
+export function IsStrongPassword(validationOptions?: ValidationOptions) {
+  return function (object: any, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsStrongPasswordConstraint,
+    });
+  };
+}

--- a/src/user/dto/validators/matches-other-property.decorator.spec.ts
+++ b/src/user/dto/validators/matches-other-property.decorator.spec.ts
@@ -1,0 +1,30 @@
+import { validate } from 'class-validator';
+import { MatchesOtherProperty } from './matches-other-property.decorator';
+
+class TestObject {
+  testMatch: string;
+  @MatchesOtherProperty('testMatch')
+  testProperty: string;
+}
+
+describe('MatchesOtherField Decorator', () => {
+  let testObject: TestObject;
+
+  beforeEach(() => (testObject = new TestObject()));
+
+  it('marks matching strings as valid', async () => {
+    testObject.testMatch = 'test';
+    testObject.testProperty = testObject.testMatch;
+
+    const errors = await validate(testObject);
+    expect(errors.length).toBe(0);
+  });
+
+  it('marks non-matching strings as invalid', async () => {
+    testObject.testMatch = 'test';
+    testObject.testProperty = 'no-match';
+
+    const errors = await validate(testObject);
+    expect(errors.length).toBe(1);
+  });
+});

--- a/src/user/dto/validators/matches-other-property.decorator.ts
+++ b/src/user/dto/validators/matches-other-property.decorator.ts
@@ -1,0 +1,42 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+export function MatchesOtherProperty(
+  property: string,
+  validationOptions?: ValidationOptions,
+) {
+  return (object: any, propertyName: string) => {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [property],
+      validator: MatchesOtherPropertyConstraint,
+    });
+  };
+}
+
+/**
+ * Checks whether a string property matches another property on the same object.
+ *
+ * Based on https://stackoverflow.com/a/60954034
+ */
+@ValidatorConstraint({ name: 'MatchOtherField' })
+export class MatchesOtherPropertyConstraint
+  implements ValidatorConstraintInterface
+{
+  validate(value: any, args: ValidationArguments) {
+    const [relatedPropertyName] = args.constraints;
+    const relatedValue = (args.object as any)[relatedPropertyName];
+    return value === relatedValue;
+  }
+
+  defaultMessage(validationArguments?: ValidationArguments): string {
+    return `${validationArguments.property} must match ${validationArguments.constraints[0]}`;
+  }
+}

--- a/src/user/user-auth.service.spec.ts
+++ b/src/user/user-auth.service.spec.ts
@@ -212,6 +212,7 @@ describe('UserAuthService', () => {
         token: tokenValue,
         userId: mockUser.id,
         password: newPassword,
+        passwordConfirmation: newPassword,
       };
 
       const mockHash = 'hashed-pw';
@@ -252,6 +253,7 @@ describe('UserAuthService', () => {
         token: 'wrong-token',
         userId: mockUser.id,
         password: newPassword,
+        passwordConfirmation: newPassword,
       };
 
       const result = async () =>

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -36,6 +36,7 @@ const defaultUser: User = {
 const createUserDto: CreateUserDto = {
   email: defaultUser.email,
   password: defaultUser.password,
+  passwordConfirmation: defaultUser.password,
   lastName: defaultUser.lastName,
   firstName: defaultUser.firstName,
 };

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -81,19 +81,20 @@ describe('UserService', () => {
   });
 
   describe('findOne', () => {
-    it('returns a user without password', async () => {
-      const addSelectMock = jest.fn();
+    it('returns a user that is inactive', async () => {
+      const whereMock = jest.fn().mockReturnThis();
       userRepositoryMock.createQueryBuilder.mockImplementation(() => {
         return {
-          where: jest.fn().mockReturnThis(),
-          addSelect: addSelectMock,
+          where: whereMock,
           getOne: jest.fn().mockReturnValueOnce(defaultUser),
         };
       });
 
       const result = await userService.findOne(defaultUser.email);
       expect(result).toEqual(defaultUser);
-      expect(addSelectMock).not.toHaveBeenCalled();
+      expect(whereMock).toHaveBeenCalledWith('user.email = :email', {
+        email: defaultUser.email,
+      });
     });
 
     it('raises NotFoundException if user is inactive and canBeInactive is not set', async () => {
@@ -122,26 +123,23 @@ describe('UserService', () => {
       expect(await userService.findOne(mockUser.email, true)).toEqual(mockUser);
     });
 
-    it('adds password if exposePassword is true', async () => {
-      const addSelectMock = jest.fn();
+    it('raises NotFoundException if inactive user exists but canBeInactive is false', async () => {
+      mockUser.isActive = false;
       userRepositoryMock.createQueryBuilder.mockImplementation(() => {
         return {
           where: jest.fn().mockReturnThis(),
-          addSelect: addSelectMock,
-          getOne: jest.fn().mockReturnValueOnce(defaultUser),
+          getOne: jest.fn().mockReturnValueOnce(mockUser),
         };
       });
 
-      await userService.findOne(defaultUser.email, false, true);
+      const result = async () => await userService.findOne(mockUser.email);
 
-      expect(addSelectMock).toHaveBeenCalledTimes(1);
-      expect(addSelectMock).toHaveBeenCalledWith('user.password');
+      await expect(result).rejects.toThrow(NotFoundException);
     });
 
     it('raises NotFoundException if user does not exist', async () => {
       userRepositoryMock.createQueryBuilder.mockImplementation(() => {
         return {
-          addSelect: jest.fn().mockReturnThis(),
           where: jest.fn().mockReturnThis(),
           getOne: jest.fn().mockReturnValueOnce(null),
         };
@@ -155,15 +153,40 @@ describe('UserService', () => {
   });
 
   describe('findOneForAuthentication', () => {
-    it('calls findOne() with correct params to choose active users only and expose the password', async () => {
-      const findOneSpy = jest
-        .spyOn(userService, 'findOne')
-        .mockReturnValue(Promise.resolve(defaultUser));
-      const { email } = defaultUser;
+    it('explicitly selects password', async () => {
+      const addSelectMock = jest.fn().mockReturnThis();
+      const whereMock = jest.fn().mockReturnThis();
+      userRepositoryMock.createQueryBuilder.mockImplementation(() => {
+        return {
+          where: whereMock,
+          addSelect: addSelectMock,
+          getOne: jest.fn().mockReturnValueOnce(defaultUser),
+        };
+      });
 
-      await userService.findOneForAuth(email);
+      const result = await userService.findOneForAuth(defaultUser.email);
 
-      expect(findOneSpy).toHaveBeenCalledWith(email, false, true);
+      expect(whereMock).toHaveBeenCalledWith(
+        'user.email = :email AND user.isActive = TRUE',
+        { email: defaultUser.email },
+      );
+      expect(addSelectMock).toHaveBeenCalledWith('user.password');
+      expect(result).toEqual(defaultUser);
+    });
+
+    it('raises NotFoundException if user does not exist', async () => {
+      userRepositoryMock.createQueryBuilder.mockImplementation(() => {
+        return {
+          where: jest.fn().mockReturnThis(),
+          addSelect: jest.fn().mockReturnThis(),
+          getOne: jest.fn().mockReturnValueOnce(null),
+        };
+      });
+      const email = 'does-not-exist@gipfeli.io';
+
+      const result = async () => await userService.findOneForAuth(email);
+
+      await expect(result).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -6,7 +6,12 @@ import {
   UserRole,
 } from './entities/user.entity';
 import { QueryFailedError, Repository } from 'typeorm';
-import { CreateUserDto, UserCreatedDto, UserDto } from './dto/user';
+import {
+  CreateUserDto,
+  UserCreatedDto,
+  UserDto,
+  UserWithPasswordDto,
+} from './dto/user';
 import { UserAlreadyExistsException } from './user.exceptions';
 import { CryptoService } from '../utils/crypto.service';
 import { UserToken, UserTokenType } from './entities/user-token.entity';
@@ -26,13 +31,23 @@ export class UserService {
   }
 
   /**
-   * Convenience method for calling findOne() with the correct params to also
-   * expose the password. Only works for active users.
+   * Looks for an active user by email and returns the object with password.
    *
    * @param email
    */
-  async findOneForAuth(email: string): Promise<UserDto> {
-    return this.findOne(email, false, true);
+  async findOneForAuth(email: string): Promise<UserWithPasswordDto> {
+    const qb = this.userRepository
+      .createQueryBuilder('user')
+      .where('user.email = :email AND user.isActive = TRUE', { email })
+      .addSelect('user.password');
+
+    const user = await qb.getOne();
+
+    if (user) {
+      return user;
+    }
+
+    throw new NotFoundException();
   }
 
   /**
@@ -41,24 +56,13 @@ export class UserService {
    * false so we always scope this to the active users only and throw a
    * UserNotActivatedException.
    *
-   * If exposePassword is set to true, it will explicitly select the password
-   * and add it to the User object.
-   *
    * @param email
    * @param canBeInactive
-   * @param exposePassword
    */
-  async findOne(
-    email: string,
-    canBeInactive = false,
-    exposePassword = false,
-  ): Promise<UserDto> {
+  async findOne(email: string, canBeInactive = false): Promise<UserDto> {
     const qb = this.userRepository
       .createQueryBuilder('user')
       .where('user.email = :email', { email });
-    if (exposePassword) {
-      qb.addSelect('user.password');
-    }
 
     const user = await qb.getOne();
 

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -36,12 +36,12 @@ export class UserService {
    * @param email
    */
   async findOneForAuth(email: string): Promise<UserWithPasswordDto> {
-    const qb = this.userRepository
+    const queryBuilder = this.userRepository
       .createQueryBuilder('user')
       .where('user.email = :email AND user.isActive = TRUE', { email })
       .addSelect('user.password');
 
-    const user = await qb.getOne();
+    const user = await queryBuilder.getOne();
 
     if (user) {
       return user;
@@ -60,11 +60,11 @@ export class UserService {
    * @param canBeInactive
    */
   async findOne(email: string, canBeInactive = false): Promise<UserDto> {
-    const qb = this.userRepository
+    const queryBuilder = this.userRepository
       .createQueryBuilder('user')
       .where('user.email = :email', { email });
 
-    const user = await qb.getOne();
+    const user = await queryBuilder.getOne();
 
     if (user) {
       if (!canBeInactive && !user.isActive) {


### PR DESCRIPTION
Fixes #40 

Adds a new validationpipe handler that transforms our errors into the format that allows us to map errors to their form fields.

![image](https://user-images.githubusercontent.com/16555423/181511614-ff72682b-c899-4900-9478-bf8c28fc0e77.png)


Furthermore:
* Update our UserDto handling, now it is clear where passwords are exposed and we're on the safer side :)
* Added password validators