### PR TITLE
Add logic to connect tour with gpx file

### DIFF
--- a/migrations/1659789051443-AddNameToGpxFileTable.ts
+++ b/migrations/1659789051443-AddNameToGpxFileTable.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNameToGpxFileTable1659789051443 implements MigrationInterface {
+  name = 'AddNameToGpxFileTable1659789051443';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "gpx_file" ADD "name" character varying`,
+    );
+    await queryRunner.query(`UPDATE "gpx_file" SET "name"="identifier"`);
+    await queryRunner.query(
+      `ALTER TABLE "gpx_file" ALTER COLUMN "name" SET NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "gpx_file" DROP COLUMN "name"`);
+  }
+}

--- a/src/media/dto/gpx-file.ts
+++ b/src/media/dto/gpx-file.ts
@@ -8,4 +8,8 @@ export class SavedGpxDto {
   @IsString()
   @IsNotEmpty()
   identifier: string;
+
+  @IsString()
+  @IsNotEmpty()
+  name: string;
 }

--- a/src/media/entities/gpx-file.entity.ts
+++ b/src/media/entities/gpx-file.entity.ts
@@ -19,6 +19,9 @@ export class GpxFile {
   @Column()
   identifier: string;
 
+  @Column()
+  name: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/media/filters/gpx-file.filter.ts
+++ b/src/media/filters/gpx-file.filter.ts
@@ -7,7 +7,7 @@ import { BadRequestException } from '@nestjs/common';
  * @param callback
  */
 const gpxFileFilter = (_req, file, callback) => {
-  return file.mimetype.match(/application\/gpx\+xml$/)
+  return file.mimetype.match(/application\/octet-stream$/) //todo: fix type or extend check
     ? callback(null, true)
     : callback(new BadRequestException('Only gpx files are allowed'), false);
 };

--- a/src/media/media.service.spec.ts
+++ b/src/media/media.service.spec.ts
@@ -59,9 +59,17 @@ const imageMocks: Image[] = [
 ] as Image[];
 
 const gpxFileMocks: GpxFile[] = [
-  { id: 'mocked-id-gpx-1', identifier: 'mocked-gpx-identifier-1' },
-  { id: 'mocked-id-gpx-2', identifier: 'mocked-gpx-identifier-2' },
-] as Image[];
+  {
+    id: 'mocked-id-gpx-1',
+    identifier: 'mocked-gpx-identifier-1',
+    name: 'mocked-gpx-name-1',
+  },
+  {
+    id: 'mocked-id-gpx-2',
+    identifier: 'mocked-gpx-identifier-2',
+    name: 'mocked-gpx-name-2',
+  },
+] as GpxFile[];
 
 describe('MediaService', () => {
   let mediaService: MediaService;

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -60,11 +60,14 @@ export class MediaService {
 
     const gpxFileEntity = this.gpxFileRepository.create({
       identifier: storedFile.identifier,
+      name: file.filename,
       user: { id: user.id },
     });
-    const { id, identifier } = await this.gpxFileRepository.save(gpxFileEntity);
+    const { id, identifier, name } = await this.gpxFileRepository.save(
+      gpxFileEntity,
+    );
 
-    return { id, identifier };
+    return { id, identifier, name };
   }
 
   public async cleanUpMedia(): Promise<CleanUpResultDto> {

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -57,10 +57,9 @@ export class MediaService {
   ): Promise<SavedGpxDto> {
     const filePath = this.getStoragePath(FilePath.GPX_FILES, user.id);
     const storedFile = await this.storageProvider.put(filePath, file);
-
     const gpxFileEntity = this.gpxFileRepository.create({
       identifier: storedFile.identifier,
-      name: file.filename,
+      name: file.originalname,
       user: { id: user.id },
     });
     const { id, identifier, name } = await this.gpxFileRepository.save(

--- a/src/tour/dto/tour.ts
+++ b/src/tour/dto/tour.ts
@@ -1,8 +1,16 @@
 import { Point } from 'geojson';
 import { OmitType, PartialType } from '@nestjs/mapped-types';
-import { IsArray, IsDate, IsNotEmpty, IsString, IsUUID } from 'class-validator';
+import {
+  IsArray,
+  IsDate,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
 import { IsPoint } from './validators/is-point.decorator';
 import { SavedImageDto } from '../../media/dto/image';
+import { SavedGpxDto } from '../../media/dto/gpx-file';
 
 export class TourDto {
   @IsUUID()
@@ -38,6 +46,9 @@ export class TourDto {
 
   @IsArray()
   images: SavedImageDto[];
+
+  @IsOptional()
+  gpxFile: SavedGpxDto;
 }
 
 export class UpdateTourDto extends PartialType(

--- a/src/tour/tour.controller.spec.ts
+++ b/src/tour/tour.controller.spec.ts
@@ -8,6 +8,7 @@ import { Image } from '../media/entities/image.entity';
 import { CreateTourDto, TourDto, UpdateTourDto } from './dto/tour';
 import { TourController } from './tour.controller';
 import { UserRole } from '../user/entities/user.entity';
+import { GpxFile } from '../media/entities/gpx-file.entity';
 
 const mockUser: AuthenticatedUserDto = {
   email: 'test@gipfeli.io',
@@ -41,6 +42,10 @@ describe('TourService', () => {
         },
         {
           provide: getRepositoryToken(Image),
+          useFactory: repositoryMockFactory,
+        },
+        {
+          provide: getRepositoryToken(GpxFile),
           useFactory: repositoryMockFactory,
         },
       ],

--- a/src/tour/tour.service.spec.ts
+++ b/src/tour/tour.service.spec.ts
@@ -14,7 +14,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { AuthenticatedUserDto } from '../user/dto/user';
 import { Image } from '../media/entities/image.entity';
 import { NotFoundException } from '@nestjs/common';
-import { UpdateTourDto } from './dto/tour';
+import { CreateTourDto, UpdateTourDto } from './dto/tour';
 import { SavedImageDto } from '../media/dto/image';
 import { UserRole } from '../user/entities/user.entity';
 import { SavedGpxDto } from '../media/dto/gpx-file';
@@ -37,6 +37,11 @@ const mockGpxFile: SavedGpxDto = {
 };
 
 const mockId = 'mocked-tour-id';
+
+const mockNewTour: CreateTourDto = {
+  description: 'test',
+  images: mockImages,
+} as CreateTourDto;
 
 describe('TourService', () => {
   let tourService: TourService;
@@ -119,8 +124,6 @@ describe('TourService', () => {
   });
 
   describe('update', () => {
-    afterEach(() => jest.clearAllMocks());
-
     it('calls the image repository with correct IDs and user scope', async () => {
       tourRepositoryMock.findOne.mockReturnValue(mockExistingTour);
       imageRepositoryMock.findByIds.mockReturnValue(mockImages);


### PR DESCRIPTION
This PR contains the logic to update the gpx file relations on update/create tour. I also added a filename to the gpx file table so we can display the file correctly in the frontend.