### PR TITLE
Fix/updating tours

### DIFF
--- a/migrations/1660651644364-AddJoinColumnToTourForGpxRelation.ts
+++ b/migrations/1660651644364-AddJoinColumnToTourForGpxRelation.ts
@@ -1,0 +1,92 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { Tour } from '../src/tour/entities/tour.entity';
+
+/**
+ * This migration fixes the wrong @JoinColumn field by moving it from the
+ * GpxFile to the Tour. It also migrates existing GPX files.
+ */
+export class AddJoinColumnToTourForGpxRelation1660651644364
+  implements MigrationInterface
+{
+  name = 'AddJoinColumnToTourForGpxRelation1660651644364';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Setup the new field on Tour
+    await queryRunner.query(`ALTER TABLE "tour" ADD "gpxFileId" uuid`);
+    await queryRunner.query(
+      `ALTER TABLE "tour" ADD CONSTRAINT "UQ_667aab08e8a0d1b02bd4ad7eea2" UNIQUE ("gpxFileId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tour" ADD CONSTRAINT "FK_667aab08e8a0d1b02bd4ad7eea2" FOREIGN KEY ("gpxFileId") REFERENCES "gpx_file"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+
+    // Migrate existing data by selecting all gpxFiles, finding their
+    // corresponding tour and then updating the tour to set the newly create field
+    const schema = await queryRunner.getCurrentSchema();
+    const gpxFiles = await queryRunner.query(
+      `SELECT * FROM ${schema}.gpx_file WHERE "tourId" IS NOT NULL`,
+    );
+
+    for (const gpxFile of gpxFiles) {
+      const tours = await queryRunner.query(
+        `SELECT * FROM ${schema}.tour WHERE id='${gpxFile.tourId}'`,
+      );
+
+      if (tours.length === 1) {
+        await queryRunner.query(
+          `UPDATE ${schema}.tour SET "gpxFileId"=$1 WHERE id=$2`,
+          [gpxFile.id, tours[0].id],
+        );
+      }
+    }
+
+    // Remove the JoinColumn from the GpxFile
+    await queryRunner.query(
+      `ALTER TABLE "gpx_file" DROP CONSTRAINT "FK_f781bfb25287d6183600114bb36"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "gpx_file" DROP CONSTRAINT "REL_f781bfb25287d6183600114bb3"`,
+    );
+    await queryRunner.query(`ALTER TABLE "gpx_file" DROP COLUMN "tourId"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Re-add to GpxFile
+    await queryRunner.query(`ALTER TABLE "gpx_file" ADD "tourId" uuid`);
+    await queryRunner.query(
+      `ALTER TABLE "gpx_file" ADD CONSTRAINT "REL_f781bfb25287d6183600114bb3" UNIQUE ("tourId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "gpx_file" ADD CONSTRAINT "FK_f781bfb25287d6183600114bb36" FOREIGN KEY ("tourId") REFERENCES "tour"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+
+    // Migrate data back
+    const schema = await queryRunner.getCurrentSchema();
+    const tours = await queryRunner.query(
+      `SELECT * FROM ${schema}.tour WHERE "gpxFileId" IS NOT NULL`,
+    );
+
+    for (const tour of tours) {
+      const gpxFiles = await queryRunner.query(
+        `SELECT * FROM ${schema}.gpx_file WHERE id='${tour.gpxFileId}'`,
+      );
+
+      if (gpxFiles.length === 1) {
+        await queryRunner.query(
+          `UPDATE ${schema}.gpx_file SET "tourId"=$1 WHERE id=$2`,
+          [tour.id, gpxFiles[0].id],
+        );
+      }
+    }
+
+    // Remove from Tour
+    await queryRunner.query(
+      `ALTER TABLE "tour" DROP CONSTRAINT "FK_667aab08e8a0d1b02bd4ad7eea2"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tour" DROP CONSTRAINT "UQ_667aab08e8a0d1b02bd4ad7eea2"`,
+    );
+    await queryRunner.query(`ALTER TABLE "tour" DROP COLUMN "gpxFileId"`);
+  }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,5 +2,5 @@ sonar.projectKey=gipfeli-io_gipfeli-api
 sonar.organization=gipfeli-io
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sources=src
-sonar.coverage.exclusions=**/main.ts,**/shared/validation/**.ts,**/shared/interceptors/**.ts,**/*.spec.ts,**/config/*.config.ts,**/*.module.ts,**/*.entity.ts,**/*.strategy.ts,**/dto/*.ts
+sonar.coverage.exclusions=**/main.ts,**/shared/validation/**.ts,**/shared/interceptors/**.ts,**/*.spec.ts,**/config/*.config.ts,**/*.module.ts,**/*.entity.ts,**/*.strategy.ts,**/dto/*.ts,**/repository-mock.factory.ts
 sonar.cpd.exclusions=**/*.spec.ts

--- a/src/media/entities/gpx-file.entity.ts
+++ b/src/media/entities/gpx-file.entity.ts
@@ -32,6 +32,5 @@ export class GpxFile {
   user?: User | null;
 
   @OneToOne(() => Tour, (tour) => tour.gpxFile, { onDelete: 'SET NULL' })
-  @JoinColumn()
   tour?: Tour | null;
 }

--- a/src/media/media.service.spec.ts
+++ b/src/media/media.service.spec.ts
@@ -206,7 +206,14 @@ describe('MediaService', () => {
     };
 
     const spyOnGxpFileRepositoryMock = (deleteResponseDb: DeleteResult) => {
-      jest.spyOn(gpxFileRepositoryMock, 'find').mockReturnValue(gpxFileMocks);
+      gpxFileRepositoryMock.createQueryBuilder.mockImplementation(() => {
+        return {
+          leftJoinAndSelect: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          orWhere: jest.fn().mockReturnThis(),
+          getMany: jest.fn().mockReturnValueOnce(gpxFileMocks),
+        };
+      });
       jest
         .spyOn(gpxFileRepositoryMock, 'delete')
         .mockReturnValue(deleteResponseDb);

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -109,16 +109,15 @@ export class MediaService {
     dateCondition: FindOperator<Date>,
   ): Promise<CleanUpResultDto> {
     // todo: add integration test for this
+    const unusedGpxFilesCondition = new Brackets((qb) => {
+      qb.where('tour.gpxFileId IS NULL').andWhere({
+        createdAt: dateCondition,
+      });
+    });
     const gpxFilesToClean = await this.gpxFileRepository
       .createQueryBuilder('gpxFile')
       .leftJoinAndSelect('gpxFile.tour', 'tour')
-      .where(
-        new Brackets((qb) => {
-          qb.where('tour.gpxFileId IS NULL').andWhere({
-            createdAt: dateCondition,
-          });
-        }),
-      )
+      .where(unusedGpxFilesCondition)
       .orWhere({ user: null })
       .getMany();
 

--- a/src/media/media.service.ts
+++ b/src/media/media.service.ts
@@ -7,7 +7,7 @@ import { UploadFileDto } from './dto/file';
 import { AuthenticatedUserDto } from '../user/dto/user';
 import { FilePath } from './enums/file-path';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOperator, LessThan, Repository } from 'typeorm';
+import { Brackets, FindOperator, LessThan, Repository } from 'typeorm';
 import { Image } from './entities/image.entity';
 import { SavedImageDto } from './dto/image';
 import {
@@ -76,7 +76,7 @@ export class MediaService {
      This does only apply for the tour conditions; media without a user is
      immediately deleted.
     */
-    const bufferDate = dayjs().subtract(1, 'day').toDate();
+    const bufferDate = dayjs().toDate();
     const dateCondition = LessThan(bufferDate);
     const imageCleanUpResultDto = await this.cleanUpImages(dateCondition);
     const gpxCleanUpResultDto = await this.cleanUpGpxFiles(dateCondition);
@@ -108,9 +108,20 @@ export class MediaService {
   private async cleanUpGpxFiles(
     dateCondition: FindOperator<Date>,
   ): Promise<CleanUpResultDto> {
-    const gpxFilesToClean = await this.gpxFileRepository.find({
-      where: [{ tour: null, createdAt: dateCondition }, { user: null }],
-    });
+    // todo: add integration test for this
+    const gpxFilesToClean = await this.gpxFileRepository
+      .createQueryBuilder('gpxFile')
+      .leftJoinAndSelect('gpxFile.tour', 'tour')
+      .where(
+        new Brackets((qb) => {
+          qb.where('tour.gpxFileId IS NULL').andWhere({
+            createdAt: dateCondition,
+          });
+        }),
+      )
+      .orWhere({ user: null })
+      .getMany();
+
     const gpxFileIdentifiers = gpxFilesToClean.map(
       (gpxFile) => gpxFile.identifier,
     );

--- a/src/tour/entities/tour.entity.ts
+++ b/src/tour/entities/tour.entity.ts
@@ -3,6 +3,7 @@ import {
   CreateDateColumn,
   Entity,
   Index,
+  JoinColumn,
   ManyToOne,
   OneToMany,
   OneToOne,
@@ -67,5 +68,6 @@ export class Tour {
     cascade: true,
     onDelete: 'SET NULL',
   })
+  @JoinColumn()
   gpxFile: GpxFile;
 }

--- a/src/utils/mock-utils/repository-mock.factory.ts
+++ b/src/utils/mock-utils/repository-mock.factory.ts
@@ -21,7 +21,10 @@ const repositoryMockFactory: () => RepositoryMockType<Repository<any>> =
     merge: jest.fn((entity) => entity),
     createQueryBuilder: jest.fn(() => ({
       innerJoinAndSelect: jest.fn().mockReturnThis(),
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
+      orWhere: jest.fn().mockReturnThis(),
+      getMany: jest.fn((entity) => [entity]),
       getOneOrFail: jest.fn((entity) => entity),
       addSelect: jest.fn().mockReturnThis(),
       getOne: jest.fn((entity) => entity),


### PR DESCRIPTION
Fixes #76 

* The `JoinColumn` was wrong. Since we're not having OneToMany as with the `Image`, the JoinColumn must be on the `Tour`, otherwise the relations cannot be synchronized. See https://github.com/typeorm/typeorm/issues/1877
* That also requires a data migration - existing GpxFiles will be migrated
* That also means that our current MediaFileCleaner does not work - hence, I had to add the querybuilder clause. It *should* be correct, but we'll have to test this. Could you check whether the cases work well?