### PR TITLE
Add endpoint for getting tour categories

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,12 +13,14 @@ import { MediaModule } from '../media/media.module';
 import mediaConfig from '../config/media.config';
 import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
+import { LookupModule } from '../lookup/lookup.module';
 
 @Module({
   imports: [
     MediaModule,
     AuthModule,
     TourModule,
+    LookupModule,
     NotificationModule,
     ConfigModule.forRoot({
       load: [

--- a/src/lookup/lookup.controller.spec.ts
+++ b/src/lookup/lookup.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LookupController } from './lookup.controller';
+
+describe('LookupController', () => {
+  let controller: LookupController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LookupController],
+    }).compile();
+
+    controller = module.get<LookupController>(LookupController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/lookup/lookup.controller.spec.ts
+++ b/src/lookup/lookup.controller.spec.ts
@@ -1,18 +1,56 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LookupController } from './lookup.controller';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import repositoryMockFactory from '../utils/mock-utils/repository-mock.factory';
+import { LookupService } from './lookup.service';
+import { TourCategory } from '../tour/entities/tour-category.entity';
 
 describe('LookupController', () => {
-  let controller: LookupController;
+  let lookupController: LookupController;
+  let lookupService: LookupService;
+  let mockTourCategories: TourCategory[];
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      controllers: [LookupController],
+      providers: [
+        LookupController,
+        LookupService,
+        {
+          provide: getRepositoryToken(TourCategory),
+          useFactory: repositoryMockFactory,
+        },
+      ],
     }).compile();
 
-    controller = module.get<LookupController>(LookupController);
+    mockTourCategories = [
+      {
+        id: 'cat-1',
+        name: 'Cat 1',
+      },
+      {
+        id: 'cat-2',
+        name: 'Cat 2',
+      },
+      {
+        id: 'cat-3',
+        name: 'Cat 3',
+      },
+    ] as TourCategory[];
+
+    lookupController = module.get<LookupController>(LookupController);
+    lookupService = module.get<LookupService>(LookupService);
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  describe('Tour Categories', () => {
+    it('Find all', async () => {
+      const spy = jest
+        .spyOn(lookupService, 'findAllTourCategories')
+        .mockReturnValue(Promise.resolve(mockTourCategories));
+
+      const result = await lookupController.findAllTourCategories();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(mockTourCategories);
+    });
   });
 });

--- a/src/lookup/lookup.controller.ts
+++ b/src/lookup/lookup.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { TourCategoryDto } from '../tour/dto/tour-category.dto';
+import { LookupService } from './lookup.service';
+
+@ApiBearerAuth()
+@ApiTags('lookup')
+@Controller('lookup')
+@UseGuards(JwtAuthGuard)
+export class LookupController {
+  constructor(private readonly lookupService: LookupService) {}
+
+  /**
+   * Returns all tour categories
+   */
+  @Get('tour-categories')
+  async findAllTourCategories(): Promise<TourCategoryDto[]> {
+    return this.lookupService.findAllTourCategories();
+  }
+}

--- a/src/lookup/lookup.module.ts
+++ b/src/lookup/lookup.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { LookupController } from './lookup.controller';
+import { LookupService } from './lookup.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TourCategory } from '../tour/entities/tour-category.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TourCategory])],
+  controllers: [LookupController],
+  providers: [LookupService],
+})
+export class LookupModule {}

--- a/src/lookup/lookup.service.spec.ts
+++ b/src/lookup/lookup.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LookupService } from './lookup.service';
+
+describe('LookupService', () => {
+  let service: LookupService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LookupService],
+    }).compile();
+
+    service = module.get<LookupService>(LookupService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/lookup/lookup.service.spec.ts
+++ b/src/lookup/lookup.service.spec.ts
@@ -1,18 +1,55 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LookupService } from './lookup.service';
+import repositoryMockFactory, {
+  RepositoryMockType,
+} from '../utils/mock-utils/repository-mock.factory';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { TourCategory } from '../tour/entities/tour-category.entity';
 
 describe('LookupService', () => {
-  let service: LookupService;
+  let lookupService: LookupService;
+  let lookupRepositoryMock: RepositoryMockType<Repository<TourCategory>>;
+  let mockTourCategories: TourCategory[];
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [LookupService],
+      providers: [
+        LookupService,
+        {
+          provide: getRepositoryToken(TourCategory),
+          useFactory: repositoryMockFactory,
+        },
+      ],
     }).compile();
 
-    service = module.get<LookupService>(LookupService);
+    mockTourCategories = [
+      {
+        id: 'cat-1',
+        name: 'Cat 1',
+      },
+      {
+        id: 'cat-2',
+        name: 'Cat 2',
+      },
+      {
+        id: 'cat-3',
+        name: 'Cat 3',
+      },
+    ] as TourCategory[];
+
+    lookupRepositoryMock = module.get(getRepositoryToken(TourCategory));
+    lookupService = module.get<LookupService>(LookupService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('Tour Categories', () => {
+    it('scopes the query to the current user and returns the result', async () => {
+      lookupRepositoryMock.find.mockReturnValue(mockTourCategories);
+
+      const result = await lookupService.findAllTourCategories();
+
+      expect(lookupRepositoryMock.find).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(mockTourCategories);
+    });
   });
 });

--- a/src/lookup/lookup.service.ts
+++ b/src/lookup/lookup.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { TourCategoryDto } from '../tour/dto/tour-category.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TourCategory } from '../tour/entities/tour-category.entity';
+
+@Injectable()
+export class LookupService {
+  constructor(
+    @InjectRepository(TourCategory)
+    private readonly tourCategoryRepository: Repository<TourCategory>,
+  ) {}
+
+  async findAllTourCategories(): Promise<TourCategoryDto[]> {
+    return this.tourCategoryRepository.find();
+  }
+}

--- a/src/tour/tour.module.ts
+++ b/src/tour/tour.module.ts
@@ -5,9 +5,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Tour } from './entities/tour.entity';
 import { Image } from '../media/entities/image.entity';
 import { GpxFile } from '../media/entities/gpx-file.entity';
+import { TourCategory } from './entities/tour-category.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Tour, Image, GpxFile])],
+  imports: [TypeOrmModule.forFeature([Tour, Image, GpxFile, TourCategory])],
   providers: [TourService],
   controllers: [TourController],
 })


### PR DESCRIPTION
I decided to introduce a controller where we can add functions returning some lookup data. As we might want to add the possibility to choose e.g. a country for the tour I thought it makes sense to already prepare this. I think it is better adding a separate module for getting lookup data lists than adding everything to the tour module.  Even though both are connected. This also adheres to the recommendations on implementing a clean api structure. 😊 So win-win. 🚀