### PR TITLE
Fix cascade of tour categories and set fix tour id

### DIFF
--- a/migrations/1661275105521-UpdateTourCategoryTable.ts
+++ b/migrations/1661275105521-UpdateTourCategoryTable.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateTourCategoryTable1661275105521
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const schema = await queryRunner.getCurrentSchema();
+    const tourCategoriesTourCategoryList = await queryRunner.query(`
+            Select * from ${schema}.tour_categories_tour_category
+        `);
+
+    //remove default value on id
+    await queryRunner.query(
+      `ALTER TABLE ${schema}.tour_category ALTER COLUMN id drop default`,
+    );
+
+    //delete existing data
+    await queryRunner.query(`
+            DELETE from ${schema}.tour_categories_tour_category
+        `);
+
+    await queryRunner.query(`
+            DELETE from ${schema}.tour_category
+        `);
+
+    //re-add data with fixed id
+    await queryRunner.query(`
+            INSERT INTO ${schema}.tour_category (id, name)
+            VALUES ('d3a76ac0-9257-49e1-9656-b27f22e8f610','Trail Run'),
+                    ('7a6507dc-ccdb-49da-9da4-bbb59ddef639','Alpine Tour'),
+                    ('4b167d23-8777-4fac-95ba-310af2bec65d','Fixed Rope Route'),
+                    ('599cc425-abb7-4f37-9eff-83c42383f799','Climbing Tour'),
+                    ('a529f9ef-3c11-40c0-a293-0fa091bfa330','Snowshoe Tour'),
+                    ('a9e105c2-081e-4703-9a86-97d201e163cd','Ski Tour'),
+                    ('d9fad132-4fcc-442e-b701-07b4bfe67d76','Walking Tour'),
+                    ('7813ea36-7f8d-47f2-9708-70366c046c80','Hike'),
+                    ('37471666-7fe4-4a48-b058-91bc80671894','Other'),
+                    ('c4c929c6-152d-49bd-8728-165ca27b4098','Bike Tour'),
+                    ('d66e0516-d060-43e9-89f5-09e646ee2e23','Stroller Trail'),
+                    ('acc0ee55-ab78-430a-936f-f6b734a69f76','Wheelchair Path')`);
+
+    for (const tourCategoryEntry of tourCategoriesTourCategoryList) {
+      await queryRunner.query(
+        `INSERT INTO ${schema}.tour_categories_tour_category VALUES($1, $2)`,
+        [tourCategoryEntry.tourId, tourCategoryEntry.tourCategoryId],
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    console.log('=> UpdateTourCategoryTable1661275105521 cannot be reverted.');
+  }
+}

--- a/src/tour/entities/tour.entity.ts
+++ b/src/tour/entities/tour.entity.ts
@@ -74,9 +74,7 @@ export class Tour {
   @JoinColumn()
   gpxFile: GpxFile;
 
-  @ManyToMany(() => TourCategory, (category) => category.tours, {
-    cascade: true,
-  })
+  @ManyToMany(() => TourCategory, (category) => category.tours)
   @JoinTable()
   categories: TourCategory[];
 }

--- a/src/tour/tour.controller.spec.ts
+++ b/src/tour/tour.controller.spec.ts
@@ -10,6 +10,7 @@ import { TourController } from './tour.controller';
 import { UserRole } from '../user/entities/user.entity';
 import { GpxFile } from '../media/entities/gpx-file.entity';
 import { TourCategoryDto } from './dto/tour-category.dto';
+import { TourCategory } from './entities/tour-category.entity';
 
 const mockUser: AuthenticatedUserDto = {
   email: 'test@gipfeli.io',
@@ -62,6 +63,10 @@ describe('TourService', () => {
         },
         {
           provide: getRepositoryToken(GpxFile),
+          useFactory: repositoryMockFactory,
+        },
+        {
+          provide: getRepositoryToken(TourCategory),
           useFactory: repositoryMockFactory,
         },
       ],

--- a/src/tour/tour.service.spec.ts
+++ b/src/tour/tour.service.spec.ts
@@ -20,6 +20,7 @@ import { UserRole } from '../user/entities/user.entity';
 import { SavedGpxFileDto } from '../media/dto/gpx-file.dto';
 import { GpxFile } from '../media/entities/gpx-file.entity';
 import { TourCategoryDto } from './dto/tour-category.dto';
+import { TourCategory } from './entities/tour-category.entity';
 
 const mockUser: AuthenticatedUserDto = {
   email: 'test@gipfeli.io',
@@ -55,6 +56,7 @@ describe('TourService', () => {
   let tourRepositoryMock: RepositoryMockType<Repository<Tour>>;
   let imageRepositoryMock: RepositoryMockType<Repository<Image>>;
   let gpxRepositoryMock: RepositoryMockType<Repository<GpxFile>>;
+  let categoryRepositoryMock: RepositoryMockType<Repository<TourCategory>>;
   let mockExistingTour: UpdateTourDto;
   let mockNewTour: CreateTourDto;
 
@@ -72,6 +74,10 @@ describe('TourService', () => {
         },
         {
           provide: getRepositoryToken(GpxFile),
+          useFactory: repositoryMockFactory,
+        },
+        {
+          provide: getRepositoryToken(TourCategory),
           useFactory: repositoryMockFactory,
         },
       ],
@@ -96,6 +102,7 @@ describe('TourService', () => {
     tourRepositoryMock = module.get(getRepositoryToken(Tour));
     imageRepositoryMock = module.get(getRepositoryToken(Image));
     gpxRepositoryMock = module.get(getRepositoryToken(GpxFile));
+    categoryRepositoryMock = module.get(getRepositoryToken(TourCategory));
   });
 
   describe('findAll', () =>
@@ -206,6 +213,7 @@ describe('TourService', () => {
       );
       imageRepositoryMock.findByIds.mockReturnValue(mockImages);
       gpxRepositoryMock.findOne.mockReturnValue(mockGpxFile);
+      categoryRepositoryMock.findByIds.mockReturnValue(mockCategories);
 
       const result = await tourService.update(
         mockId,
@@ -221,7 +229,6 @@ describe('TourService', () => {
       const expectedDto = {
         description: mockTourWithoutImage.description,
         id: mockTourWithoutImage.id,
-        categories: mockCategories,
       };
       expect(tourRepositoryMock.merge).toHaveBeenCalledTimes(1);
       expect(tourRepositoryMock.merge).toHaveBeenCalledWith(
@@ -239,6 +246,7 @@ describe('TourService', () => {
       );
       gpxRepositoryMock.findOne.mockReturnValue(mockGpxFile);
       imageRepositoryMock.findByIds.mockReturnValue(mockImages);
+      categoryRepositoryMock.findByIds.mockReturnValue(mockCategories);
 
       const result = await tourService.update(
         mockId,
@@ -253,7 +261,6 @@ describe('TourService', () => {
       const expectedDto = {
         description: mockTourWithoutGxpFile.description,
         id: mockTourWithoutGxpFile.id,
-        categories: mockCategories,
       };
 
       expect(tourRepositoryMock.merge).toHaveBeenCalledTimes(1);
@@ -272,6 +279,7 @@ describe('TourService', () => {
       );
       gpxRepositoryMock.findOne.mockReturnValue(mockGpxFile);
       imageRepositoryMock.findByIds.mockReturnValue(mockImages);
+      categoryRepositoryMock.findByIds.mockReturnValue(mockCategories);
 
       const result = await tourService.update(
         mockId,
@@ -286,7 +294,6 @@ describe('TourService', () => {
       const expectedDto = {
         description: mockTourWithoutGpxFile.description,
         id: mockTourWithoutGpxFile.id,
-        categories: mockCategories,
       };
       expect(tourRepositoryMock.merge).toHaveBeenCalledTimes(1);
       expect(tourRepositoryMock.merge).toHaveBeenCalledWith(
@@ -314,8 +321,9 @@ describe('TourService', () => {
       tourRepositoryMock.save.mockReturnValue(mockNewTour);
       imageRepositoryMock.findByIds.mockReturnValue(mockImages);
       gpxRepositoryMock.findOne.mockReturnValue(mockGpxFile);
+      categoryRepositoryMock.findByIds.mockReturnValue(mockCategories);
 
-      const { images, gpxFile, ...tourData } = mockNewTour;
+      const { images, gpxFile, categories, ...tourData } = mockNewTour;
 
       const result = await tourService.create(mockNewTour, mockUser);
 
@@ -323,6 +331,7 @@ describe('TourService', () => {
         user: mockUser,
         images: mockImages,
         gpxFile: mockGpxFile,
+        categories: mockCategories,
         ...tourData,
       };
       expect(tourRepositoryMock.create).toHaveBeenCalledTimes(1);
@@ -339,7 +348,9 @@ describe('TourService', () => {
       tourRepositoryMock.save.mockReturnValue(mockNewTour);
       imageRepositoryMock.findByIds.mockReturnValue(mockImages);
       gpxRepositoryMock.findOne.mockReturnValue(mockGpxFile);
-      const { images, gpxFile, ...tourData } = mockNewTour;
+      categoryRepositoryMock.findByIds.mockReturnValue(mockCategories);
+
+      const { images, gpxFile, categories, ...tourData } = mockNewTour;
 
       const result = await tourService.create(mockNewTour, mockUser);
 
@@ -347,6 +358,7 @@ describe('TourService', () => {
         user: mockUser,
         images: mockImages,
         gpxFile: mockGpxFile,
+        categories: mockCategories,
         ...tourData,
       };
       expect(tourRepositoryMock.create).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
I removed the cascade: true setting on the tour categories and changed the update and create functions.
What I also did was change the category table a bit. I want to display icons in the frontend for each category. To do that I have to have an id  for each category that does not change (similar to having it as an enum). As the category table is kind of a given set of things and the id should not change in the future I decided to remove the auto generation feature in the table and set the id manually. Like this the ids will always be the same even if we re-generate the database. 
I used this in other projects too for lookup tables like e.g. country, status configs etc. It's kind of like saving extended enums in the db. :D 