### PR TITLE
Feature/more integration tests

### DIFF
--- a/src/tour/dto/tour.dto.ts
+++ b/src/tour/dto/tour.dto.ts
@@ -69,7 +69,6 @@ export class TourDto {
   userId: string;
 
   @IsArray()
-  @ValidateNested({ each: true })
   @Type(() => SavedImageDto)
   images: SavedImageDto[];
 

--- a/src/tour/tour.service.spec.ts
+++ b/src/tour/tour.service.spec.ts
@@ -157,7 +157,10 @@ describe('TourService', () => {
 
       const expectedIds = mockImages.map((image) => image.id);
       const expectedConditions: FindManyOptions<Image> = {
-        where: { user: mockUser },
+        where: [
+          { userId: mockUser.id, tourId: null },
+          { userId: mockUser.id, tourId: mockExistingTour.id },
+        ],
       };
 
       expect(imageRepositoryMock.findByIds).toHaveBeenCalledTimes(1);
@@ -175,6 +178,7 @@ describe('TourService', () => {
 
       const expectedConditions: FindManyOptions<GpxFile> = {
         where: { user: mockUser },
+        relations: ['tour'],
       };
 
       expect(gpxRepositoryMock.findOne).toHaveBeenCalledTimes(1);
@@ -212,7 +216,7 @@ describe('TourService', () => {
         Object.assign({}, mockTourWithoutImage),
       );
       imageRepositoryMock.findByIds.mockReturnValue(mockImages);
-      gpxRepositoryMock.findOne.mockReturnValue(mockGpxFile);
+      gpxRepositoryMock.findOne.mockReturnValue(null);
       categoryRepositoryMock.findByIds.mockReturnValue(mockCategories);
 
       const result = await tourService.update(
@@ -224,6 +228,7 @@ describe('TourService', () => {
       // Merge is called with the entity (added with images) and the DTO (without images)
       const expectedEntity = {
         ...mockTourWithoutImage,
+        gpxFile: null,
         images: mockImages,
       };
       const expectedDto = {
@@ -239,6 +244,8 @@ describe('TourService', () => {
     });
 
     it('sets the gpx file property on the tour and merges the entity with the DTO', async () => {
+      // @ts-ignore => Mock an empty gpx file which can be assigned
+      mockGpxFile.tour = null;
       const mockTourWithoutGxpFile = Object.assign({}, mockExistingTour);
       mockTourWithoutGxpFile.gpxFile = null;
       tourRepositoryMock.findOne.mockReturnValue(
@@ -320,7 +327,7 @@ describe('TourService', () => {
       tourRepositoryMock.create.mockReturnValue(mockNewTour);
       tourRepositoryMock.save.mockReturnValue(mockNewTour);
       imageRepositoryMock.findByIds.mockReturnValue(mockImages);
-      gpxRepositoryMock.findOne.mockReturnValue(mockGpxFile);
+      gpxRepositoryMock.findOne.mockReturnValue(null);
       categoryRepositoryMock.findByIds.mockReturnValue(mockCategories);
 
       const { images, gpxFile, categories, ...tourData } = mockNewTour;
@@ -330,7 +337,7 @@ describe('TourService', () => {
       const expectedConditions = {
         user: mockUser,
         images: mockImages,
-        gpxFile: mockGpxFile,
+        gpxFile: null,
         categories: mockCategories,
         ...tourData,
       };
@@ -344,6 +351,8 @@ describe('TourService', () => {
     });
 
     it('creates a tour with assigned gpx file and returns it', async () => {
+      // @ts-ignore => Mock an empty gpx file which can be assigned
+      mockGpxFile.tour = null;
       tourRepositoryMock.create.mockReturnValue(mockNewTour);
       tourRepositoryMock.save.mockReturnValue(mockNewTour);
       imageRepositoryMock.findByIds.mockReturnValue(mockImages);
@@ -377,7 +386,7 @@ describe('TourService', () => {
 
       const expectedIds = mockImages.map((image) => image.id);
       const expectedConditions: FindManyOptions<Image> = {
-        where: { user: mockUser },
+        where: { userId: mockUser.id, tourId: null },
       };
 
       expect(imageRepositoryMock.findByIds).toHaveBeenCalledTimes(1);
@@ -388,12 +397,15 @@ describe('TourService', () => {
     });
 
     it('calls the gpx file repository with the correct id and user scope', async () => {
+      // @ts-ignore => Mock an empty gpx file which can be assigned
+      mockGpxFile.tour = null;
       gpxRepositoryMock.findOne.mockReturnValue(mockGpxFile);
 
       await tourService.create(mockNewTour, mockUser);
 
       const expectedConditions: FindManyOptions<GpxFile> = {
         where: { user: mockUser },
+        relations: ['tour'],
       };
 
       expect(gpxRepositoryMock.findOne).toHaveBeenCalledTimes(1);
@@ -403,6 +415,7 @@ describe('TourService', () => {
       );
     });
   });
+
   describe('delete', () => {
     it('deletes an existing tour scoped to the user', async () => {
       tourRepositoryMock.delete.mockReturnValue({ affected: 1 });

--- a/test/e2e/jwt-strategies/jwt-auth-guards.e2e-spec.ts
+++ b/test/e2e/jwt-strategies/jwt-auth-guards.e2e-spec.ts
@@ -19,9 +19,7 @@ import { TokenDto } from '../../../src/auth/dto/auth.dto';
 import { UserRole } from '../../../src/user/entities/user.entity';
 import createLogin from '../utils/create-login';
 import { TourModule } from '../../../src/tour/tour.module';
-
-const AUTH_ROUTE_PREFIX = '/auth';
-const TOUR_ROUTE_PREFIX = '/tours';
+import { RoutePrefix } from '../utils/route-prefix';
 
 describe('Check that guards check for the correct token', () => {
   let app: INestApplication;
@@ -71,14 +69,14 @@ describe('Check that guards check for the correct token', () => {
   describe('RefreshTokenGuard', () => {
     it('it fails if an access token is sent', () => {
       return request(app.getHttpServer())
-        .post(`${AUTH_ROUTE_PREFIX}/refresh`)
+        .post(`${RoutePrefix.AUTH}/refresh`)
         .set('Authorization', 'Bearer ' + tokens.accessToken)
         .expect(401);
     });
 
     it('it succeeds if a refresh token is sent', () => {
       return request(app.getHttpServer())
-        .post(`${AUTH_ROUTE_PREFIX}/refresh`)
+        .post(`${RoutePrefix.AUTH}/refresh`)
         .set('Authorization', 'Bearer ' + tokens.refreshToken)
         .expect(201);
     });
@@ -87,14 +85,14 @@ describe('Check that guards check for the correct token', () => {
   describe('JwtAuthGuard', () => {
     it('it fails if a refresh token is sent', () => {
       return request(app.getHttpServer())
-        .get(`${TOUR_ROUTE_PREFIX}/`)
+        .get(`${RoutePrefix.TOUR}/`)
         .set('Authorization', 'Bearer ' + tokens.refreshToken)
         .expect(401);
     });
 
     it('it succeeds if an access token is sent', () => {
       return request(app.getHttpServer())
-        .get(`${TOUR_ROUTE_PREFIX}/`)
+        .get(`${RoutePrefix.TOUR}/`)
         .set('Authorization', 'Bearer ' + tokens.accessToken)
         .expect(200);
     });

--- a/test/e2e/route-access/admin.e2e-spec.ts
+++ b/test/e2e/route-access/admin.e2e-spec.ts
@@ -21,9 +21,7 @@ import { CryptoService } from '../../../src/utils/crypto.service';
 import { UserSession } from '../../../src/auth/entities/user-session.entity';
 import { AuthModule } from '../../../src/auth/auth.module';
 import { MediaModule } from '../../../src/media/media.module';
-
-const USER_ROUTE_PREFIX = '/users';
-const MEDIA_ROUTE_PREFIX = '/media';
+import { RoutePrefix } from '../utils/route-prefix';
 
 describe('Admin Routes can be accessed by an admin user', () => {
   let app: INestApplication;
@@ -75,7 +73,7 @@ describe('Admin Routes can be accessed by an admin user', () => {
   describe('User', () => {
     it('/ (POST)', () => {
       return request(app.getHttpServer())
-        .get(`${USER_ROUTE_PREFIX}/`)
+        .get(`${RoutePrefix.USER}/`)
         .set('Authorization', 'Bearer ' + tokens.accessToken)
         .expect(200);
     });
@@ -86,7 +84,7 @@ describe('Admin Routes can be accessed by an admin user', () => {
       await userRepository.save(newUser);
 
       return request(app.getHttpServer())
-        .delete(`${USER_ROUTE_PREFIX}/${newUser.id}`)
+        .delete(`${RoutePrefix.USER}/${newUser.id}`)
         .set('Authorization', 'Bearer ' + tokens.accessToken)
         .expect(200);
     });
@@ -95,7 +93,7 @@ describe('Admin Routes can be accessed by an admin user', () => {
   describe('cleanUpMedia throws 401 as different token is required', () => {
     it('/clean-up-media (GET)', () => {
       return request(app.getHttpServer())
-        .get(`${MEDIA_ROUTE_PREFIX}/clean-up-media`)
+        .get(`${RoutePrefix.MEDIA}/clean-up-media`)
         .set('Authorization', 'Bearer ' + tokens.accessToken)
         .expect(401);
     });

--- a/test/e2e/route-access/anonymous.e2e-spec.ts
+++ b/test/e2e/route-access/anonymous.e2e-spec.ts
@@ -14,12 +14,7 @@ import { randomUUID } from 'crypto';
 import { TourModule } from '../../../src/tour/tour.module';
 import { LookupModule } from '../../../src/lookup/lookup.module';
 import { MediaModule } from '../../../src/media/media.module';
-
-const AUTH_ROUTE_PREFIX = '/auth';
-const USER_ROUTE_PREFIX = '/users';
-const TOUR_ROUTE_PREFIX = '/tours';
-const LOOKUP_ROUTE_PREFIX = '/lookup';
-const MEDIA_ROUTE_PREFIX = '/media';
+import { RoutePrefix } from '../utils/route-prefix';
 
 describe('Anonymous route access on protected routes throws 401', () => {
   let app: INestApplication;
@@ -60,7 +55,7 @@ describe('Anonymous route access on protected routes throws 401', () => {
   describe('Auth', () => {
     it('/refresh (POST)', () => {
       return request(app.getHttpServer())
-        .post(`${AUTH_ROUTE_PREFIX}/refresh`)
+        .post(`${RoutePrefix.AUTH}/refresh`)
         .expect(401);
     });
   });
@@ -68,7 +63,7 @@ describe('Anonymous route access on protected routes throws 401', () => {
   describe('Lookup', () => {
     it('/tour-categories (POST)', () => {
       return request(app.getHttpServer())
-        .get(`${LOOKUP_ROUTE_PREFIX}/tour-categories`)
+        .get(`${RoutePrefix.LOOKUP}/tour-categories`)
         .expect(401);
     });
   });
@@ -76,19 +71,19 @@ describe('Anonymous route access on protected routes throws 401', () => {
   describe('Media', () => {
     it('/upload-image (POST)', () => {
       return request(app.getHttpServer())
-        .post(`${MEDIA_ROUTE_PREFIX}/upload-image`)
+        .post(`${RoutePrefix.MEDIA}/upload-image`)
         .expect(401);
     });
 
     it('/upload-gpx-file (POST)', () => {
       return request(app.getHttpServer())
-        .post(`${MEDIA_ROUTE_PREFIX}/upload-gpx-file`)
+        .post(`${RoutePrefix.MEDIA}/upload-gpx-file`)
         .expect(401);
     });
 
     it('/clean-up-media (GET)', () => {
       return request(app.getHttpServer())
-        .get(`${MEDIA_ROUTE_PREFIX}/clean-up-media`)
+        .get(`${RoutePrefix.MEDIA}/clean-up-media`)
         .expect(401);
     });
   });
@@ -96,14 +91,14 @@ describe('Anonymous route access on protected routes throws 401', () => {
   describe('Users', () => {
     it('/ (POST)', () => {
       return request(app.getHttpServer())
-        .get(`${USER_ROUTE_PREFIX}/`)
+        .get(`${RoutePrefix.USER}/`)
         .expect(401);
     });
 
     it('/:id (DELETE)', () => {
       const uuid = randomUUID();
       return request(app.getHttpServer())
-        .delete(`${USER_ROUTE_PREFIX}/${uuid}`)
+        .delete(`${RoutePrefix.USER}/${uuid}`)
         .expect(401);
     });
   });
@@ -111,34 +106,34 @@ describe('Anonymous route access on protected routes throws 401', () => {
   describe('Tours', () => {
     it('/ (POST)', () => {
       return request(app.getHttpServer())
-        .get(`${TOUR_ROUTE_PREFIX}/`)
+        .get(`${RoutePrefix.TOUR}/`)
         .expect(401);
     });
 
     it('/ (POST)', () => {
       return request(app.getHttpServer())
-        .post(`${TOUR_ROUTE_PREFIX}/`)
+        .post(`${RoutePrefix.TOUR}/`)
         .expect(401);
     });
 
     it('/:id (GET)', () => {
       const uuid = randomUUID();
       return request(app.getHttpServer())
-        .get(`${TOUR_ROUTE_PREFIX}/${uuid}`)
+        .get(`${RoutePrefix.TOUR}/${uuid}`)
         .expect(401);
     });
 
     it('/:id (PATCH)', () => {
       const uuid = randomUUID();
       return request(app.getHttpServer())
-        .patch(`${TOUR_ROUTE_PREFIX}/${uuid}`)
+        .patch(`${RoutePrefix.TOUR}/${uuid}`)
         .expect(401);
     });
 
     it('/:id (DELETE)', () => {
       const uuid = randomUUID();
       return request(app.getHttpServer())
-        .delete(`${TOUR_ROUTE_PREFIX}/${uuid}`)
+        .delete(`${RoutePrefix.TOUR}/${uuid}`)
         .expect(401);
     });
   });

--- a/test/e2e/route-access/authenticated-user.e2e-spec.ts
+++ b/test/e2e/route-access/authenticated-user.e2e-spec.ts
@@ -32,12 +32,7 @@ import { UserSession } from '../../../src/auth/entities/user-session.entity';
 import { TokenDto } from '../../../src/auth/dto/auth.dto';
 import { UserRole } from '../../../src/user/entities/user.entity';
 import createLogin from '../utils/create-login';
-
-const AUTH_ROUTE_PREFIX = '/auth';
-const USER_ROUTE_PREFIX = '/users';
-const TOUR_ROUTE_PREFIX = '/tours';
-const LOOKUP_ROUTE_PREFIX = '/lookup';
-const MEDIA_ROUTE_PREFIX = '/media';
+import { RoutePrefix } from '../utils/route-prefix';
 
 const fileResponseMock: UploadedFileHandle = {
   identifier: 'mocked-identifier',
@@ -105,7 +100,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
     describe('Auth', () => {
       it('/refresh (POST)', () => {
         return request(app.getHttpServer())
-          .post(`${AUTH_ROUTE_PREFIX}/refresh`)
+          .post(`${RoutePrefix.AUTH}/refresh`)
           .set('Authorization', 'Bearer ' + tokens.refreshToken)
           .expect(201);
       });
@@ -114,7 +109,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
     describe('Lookup', () => {
       it('/tour-categories (POST)', () => {
         return request(app.getHttpServer())
-          .get(`${LOOKUP_ROUTE_PREFIX}/tour-categories`)
+          .get(`${RoutePrefix.LOOKUP}/tour-categories`)
           .set('Authorization', 'Bearer ' + tokens.accessToken)
           .expect(200);
       });
@@ -125,7 +120,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
         const mockFile = path.join(__dirname, '../../mocks/image_with_gps.jpg');
 
         return request(app.getHttpServer())
-          .post(`${MEDIA_ROUTE_PREFIX}/upload-image`)
+          .post(`${RoutePrefix.MEDIA}/upload-image`)
           .set('Authorization', 'Bearer ' + tokens.accessToken)
           .attach('file', mockFile)
           .expect(201);
@@ -136,7 +131,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
         const buffer = fs.readFileSync(mockFile);
 
         return request(app.getHttpServer())
-          .post(`${MEDIA_ROUTE_PREFIX}/upload-gpx-file`)
+          .post(`${RoutePrefix.MEDIA}/upload-gpx-file`)
           .set('Authorization', 'Bearer ' + tokens.accessToken)
           .attach('file', mockFile, {
             filename: 'test.gpx',
@@ -149,7 +144,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
     describe('Tours', () => {
       it('/ (GET)', () => {
         return request(app.getHttpServer())
-          .get(`${TOUR_ROUTE_PREFIX}/`)
+          .get(`${RoutePrefix.TOUR}/`)
           .set('Authorization', 'Bearer ' + tokens.accessToken)
           .expect(200);
       });
@@ -157,7 +152,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
       it('/ (POST)', () => {
         const tour = EntityCreator.createTour(userToCheckAgainst);
         return request(app.getHttpServer())
-          .post(`${TOUR_ROUTE_PREFIX}/`)
+          .post(`${RoutePrefix.TOUR}/`)
           .set('Authorization', 'Bearer ' + tokens.accessToken)
           .send({ ...tour })
           .expect(201);
@@ -169,7 +164,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
         });
 
         return request(app.getHttpServer())
-          .get(`${TOUR_ROUTE_PREFIX}/${tour.id}`)
+          .get(`${RoutePrefix.TOUR}/${tour.id}`)
           .set('Authorization', 'Bearer ' + tokens.accessToken)
           .expect(200);
       });
@@ -180,7 +175,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
         await tourRepository.save(newTour);
 
         return request(app.getHttpServer())
-          .patch(`${TOUR_ROUTE_PREFIX}/${newTour.id}`)
+          .patch(`${RoutePrefix.TOUR}/${newTour.id}`)
           .set('Authorization', 'Bearer ' + tokens.accessToken)
           .send({ name: 'Changing the name', images: [], categories: [] })
           .expect(200);
@@ -192,7 +187,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
         await tourRepository.save(newTour);
 
         return request(app.getHttpServer())
-          .delete(`${TOUR_ROUTE_PREFIX}/${newTour.id}`)
+          .delete(`${RoutePrefix.TOUR}/${newTour.id}`)
           .set('Authorization', 'Bearer ' + tokens.accessToken)
           .expect(200);
       });
@@ -202,7 +197,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
   describe('User routes throw 403 as admin is required', () => {
     it('/ (POST)', () => {
       return request(app.getHttpServer())
-        .get(`${USER_ROUTE_PREFIX}/`)
+        .get(`${RoutePrefix.USER}/`)
         .set('Authorization', 'Bearer ' + tokens.accessToken)
         .expect(403);
     });
@@ -210,7 +205,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
     it('/:id (DELETE)', () => {
       const uuid = randomUUID();
       return request(app.getHttpServer())
-        .delete(`${USER_ROUTE_PREFIX}/${uuid}`)
+        .delete(`${RoutePrefix.USER}/${uuid}`)
         .set('Authorization', 'Bearer ' + tokens.accessToken)
         .expect(403);
     });
@@ -219,7 +214,7 @@ describe('Authenticated user routes can be accessed by a logged-in user', () => 
   describe('cleanUpMedia throws 401 as different token is required', () => {
     it('/clean-up-media (GET)', () => {
       return request(app.getHttpServer())
-        .get(`${MEDIA_ROUTE_PREFIX}/clean-up-media`)
+        .get(`${RoutePrefix.MEDIA}/clean-up-media`)
         .set('Authorization', 'Bearer ' + tokens.accessToken)
         .expect(401);
     });

--- a/test/e2e/route-access/clean-up-token.e2e-spec.ts
+++ b/test/e2e/route-access/clean-up-token.e2e-spec.ts
@@ -14,16 +14,11 @@ import { randomUUID } from 'crypto';
 import { TourModule } from '../../../src/tour/tour.module';
 import { LookupModule } from '../../../src/lookup/lookup.module';
 import { MediaModule } from '../../../src/media/media.module';
-
-const AUTH_ROUTE_PREFIX = '/auth';
-const USER_ROUTE_PREFIX = '/users';
-const TOUR_ROUTE_PREFIX = '/tours';
-const LOOKUP_ROUTE_PREFIX = '/lookup';
-const MEDIA_ROUTE_PREFIX = '/media';
+import { RoutePrefix } from '../utils/route-prefix';
 
 describe('Cleanup token only allows access to cleanUpMedia, but not to any other route', () => {
   let app: INestApplication;
-  const cleanUpToken = process.env.CLEAN_UP_TOKEN
+  const cleanUpToken = process.env.CLEAN_UP_TOKEN;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -61,7 +56,7 @@ describe('Cleanup token only allows access to cleanUpMedia, but not to any other
   describe('Auth', () => {
     it('/refresh (POST)', () => {
       return request(app.getHttpServer())
-        .post(`${AUTH_ROUTE_PREFIX}/refresh`)
+        .post(`${RoutePrefix.AUTH}/refresh`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(401);
     });
@@ -70,7 +65,7 @@ describe('Cleanup token only allows access to cleanUpMedia, but not to any other
   describe('Lookup', () => {
     it('/tour-categories (POST)', () => {
       return request(app.getHttpServer())
-        .get(`${LOOKUP_ROUTE_PREFIX}/tour-categories`)
+        .get(`${RoutePrefix.LOOKUP}/tour-categories`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(401);
     });
@@ -79,21 +74,21 @@ describe('Cleanup token only allows access to cleanUpMedia, but not to any other
   describe('Media', () => {
     it('/upload-image (POST)', () => {
       return request(app.getHttpServer())
-        .post(`${MEDIA_ROUTE_PREFIX}/upload-image`)
+        .post(`${RoutePrefix.MEDIA}/upload-image`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(401);
     });
 
     it('/upload-gpx-file (POST)', () => {
       return request(app.getHttpServer())
-        .post(`${MEDIA_ROUTE_PREFIX}/upload-gpx-file`)
+        .post(`${RoutePrefix.MEDIA}/upload-gpx-file`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(401);
     });
 
     it('/clean-up-media (GET)', () => {
       return request(app.getHttpServer())
-        .get(`${MEDIA_ROUTE_PREFIX}/clean-up-media`)
+        .get(`${RoutePrefix.MEDIA}/clean-up-media`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(200);
     });
@@ -102,7 +97,7 @@ describe('Cleanup token only allows access to cleanUpMedia, but not to any other
   describe('Users', () => {
     it('/ (POST)', () => {
       return request(app.getHttpServer())
-        .get(`${USER_ROUTE_PREFIX}/`)
+        .get(`${RoutePrefix.USER}/`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(401);
     });
@@ -110,7 +105,7 @@ describe('Cleanup token only allows access to cleanUpMedia, but not to any other
     it('/:id (DELETE)', () => {
       const uuid = randomUUID();
       return request(app.getHttpServer())
-        .delete(`${USER_ROUTE_PREFIX}/${uuid}`)
+        .delete(`${RoutePrefix.USER}/${uuid}`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(401);
     });
@@ -119,14 +114,14 @@ describe('Cleanup token only allows access to cleanUpMedia, but not to any other
   describe('Tours', () => {
     it('/ (POST)', () => {
       return request(app.getHttpServer())
-        .get(`${TOUR_ROUTE_PREFIX}/`)
+        .get(`${RoutePrefix.TOUR}/`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(401);
     });
 
     it('/ (POST)', () => {
       return request(app.getHttpServer())
-        .post(`${TOUR_ROUTE_PREFIX}/`)
+        .post(`${RoutePrefix.TOUR}/`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(401);
     });
@@ -134,7 +129,7 @@ describe('Cleanup token only allows access to cleanUpMedia, but not to any other
     it('/:id (GET)', () => {
       const uuid = randomUUID();
       return request(app.getHttpServer())
-        .get(`${TOUR_ROUTE_PREFIX}/${uuid}`)
+        .get(`${RoutePrefix.TOUR}/${uuid}`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(401);
     });
@@ -142,7 +137,7 @@ describe('Cleanup token only allows access to cleanUpMedia, but not to any other
     it('/:id (PATCH)', () => {
       const uuid = randomUUID();
       return request(app.getHttpServer())
-        .patch(`${TOUR_ROUTE_PREFIX}/${uuid}`)
+        .patch(`${RoutePrefix.TOUR}/${uuid}`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(401);
     });
@@ -150,7 +145,7 @@ describe('Cleanup token only allows access to cleanUpMedia, but not to any other
     it('/:id (DELETE)', () => {
       const uuid = randomUUID();
       return request(app.getHttpServer())
-        .delete(`${TOUR_ROUTE_PREFIX}/${uuid}`)
+        .delete(`${RoutePrefix.TOUR}/${uuid}`)
         .set('Authorization', 'Bearer ' + cleanUpToken)
         .expect(401);
     });

--- a/test/e2e/tour/tour-gpx-file-handling.e2e-spec.ts
+++ b/test/e2e/tour/tour-gpx-file-handling.e2e-spec.ts
@@ -1,0 +1,246 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../../../src/auth/auth.module';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import databaseConfig from '../../../src/config/database.config';
+import securityConfig from '../../../src/config/security.config';
+import environmentConfig from '../../../src/config/environment.config';
+import integrationsConfig from '../../../src/config/integrations.config';
+import mediaConfig from '../../../src/config/media.config';
+import { UserModule } from '../../../src/user/user.module';
+import { TourModule } from '../../../src/tour/tour.module';
+import { LookupModule } from '../../../src/lookup/lookup.module';
+import { MediaModule } from '../../../src/media/media.module';
+import { Repository } from 'typeorm';
+import { Tour } from '../../../src/tour/entities/tour.entity';
+import { Seeder } from '../utils/seeder';
+import { AuthService } from '../../../src/auth/auth.service';
+import { JwtService } from '@nestjs/jwt';
+import { CryptoService } from '../../../src/utils/crypto.service';
+import { UserSession } from '../../../src/auth/entities/user-session.entity';
+import { TokenDto } from '../../../src/auth/dto/auth.dto';
+import { User, UserRole } from '../../../src/user/entities/user.entity';
+import createLogin from '../utils/create-login';
+import { EntityCreator } from '../utils/entity-creator';
+import { CreateTourDto, UpdateTourDto } from '../../../src/tour/dto/tour.dto';
+import { faker } from '@faker-js/faker';
+import { Point } from 'geojson';
+import { RoutePrefix } from '../utils/route-prefix';
+import { GpxFile } from '../../../src/media/entities/gpx-file.entity';
+
+const fakePoint: Point = {
+  type: 'Point',
+  coordinates: [7.920462, 47.328439],
+};
+
+describe('Tour', () => {
+  let app: INestApplication;
+  let tourRepository: Repository<Tour>;
+  let gpxFileRepository: Repository<GpxFile>;
+  let userRepository: Repository<User>;
+  let authService: AuthService;
+  let tokens: TokenDto;
+  const userToCheckAgainst = Seeder.getSeeds().users.find(
+    (user) => user.role === UserRole.USER,
+  );
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRootAsync({
+          imports: [
+            ConfigModule.forRoot({
+              load: [databaseConfig],
+            }),
+          ],
+          useFactory: (configService: ConfigService) =>
+            configService.get('database'),
+          inject: [ConfigService],
+        }),
+        TypeOrmModule.forFeature([UserSession]),
+        ConfigModule.forRoot({
+          load: [
+            securityConfig,
+            environmentConfig,
+            integrationsConfig,
+            mediaConfig,
+          ],
+        }),
+        AuthModule,
+        UserModule,
+        TourModule,
+        LookupModule,
+        MediaModule,
+      ],
+      providers: [AuthService, JwtService, CryptoService],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    tourRepository = moduleFixture.get('TourRepository');
+    gpxFileRepository = moduleFixture.get('GpxFileRepository');
+    userRepository = moduleFixture.get('UserRepository');
+    authService = moduleFixture.get(AuthService);
+    tokens = await createLogin(authService, userToCheckAgainst);
+
+    await app.init();
+  });
+
+  describe('Gpx File handling', () => {
+    it('creating a tour assigns uploaded GPX file in the create request to the tour', async () => {
+      const gpxFile = await gpxFileRepository.save(
+        EntityCreator.createGpxFile(userToCheckAgainst),
+      );
+
+      const tour: CreateTourDto = {
+        name: faker.lorem.sentence(2),
+        description: faker.lorem.sentences(10),
+        endLocation: fakePoint,
+        startLocation: fakePoint,
+        images: [],
+        categories: [],
+        gpxFile: gpxFile,
+      };
+
+      await request(app.getHttpServer())
+        .post(`${RoutePrefix.TOUR}/`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .send({ ...tour });
+
+      const createdTour = await tourRepository.findOne(
+        {
+          name: tour.name,
+          description: tour.description,
+        },
+        { relations: ['gpxFile'] },
+      );
+
+      expect(createdTour.gpxFile.id).toEqual(gpxFile.id);
+    });
+
+    it('updating a tour correctly updates gpxFile relation', async () => {
+      const gpxFile = await gpxFileRepository.save(
+        EntityCreator.createGpxFile(userToCheckAgainst),
+      );
+      const tour = await tourRepository.save(
+        EntityCreator.createTour(userToCheckAgainst, [], gpxFile),
+      );
+
+      const newGpxFile = await gpxFileRepository.save(
+        EntityCreator.createGpxFile(userToCheckAgainst),
+      );
+      const updateTour: UpdateTourDto = {
+        gpxFile: newGpxFile,
+        images: [],
+        categories: [],
+      };
+
+      await request(app.getHttpServer())
+        .patch(`${RoutePrefix.TOUR}/${tour.id}`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .send({ ...updateTour });
+
+      const updatedTour = await tourRepository.findOne(tour.id, {
+        relations: ['gpxFile'],
+      });
+
+      expect(updatedTour.gpxFile.id).toEqual(newGpxFile.id);
+    });
+
+    it('assigning a gpxFile that does not exist in the database fails silently', async () => {
+      // Note: this test is only checked against the update route; the create
+      // route uses the same flow.
+      const tour = await tourRepository.save(
+        EntityCreator.createTour(userToCheckAgainst),
+      );
+      const gpxFile = EntityCreator.createGpxFile(userToCheckAgainst);
+
+      const updateTour: UpdateTourDto = {
+        gpxFile: gpxFile,
+        images: [],
+        categories: [],
+      };
+
+      const response = await request(app.getHttpServer())
+        .patch(`${RoutePrefix.TOUR}/${tour.id}`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .send({ ...updateTour });
+
+      const updatedTour = await tourRepository.findOne(tour.id, {
+        relations: ['gpxFile'],
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(updatedTour.gpxFile).toEqual(null);
+    });
+
+    it('assigning a gpxFile that belongs to another user fails silently', async () => {
+      // Note: this test is only checked against the update route; the create
+      // route uses the same flow.
+      const tour = await tourRepository.save(
+        EntityCreator.createTour(userToCheckAgainst),
+      );
+
+      const otherUser = await userRepository.save(EntityCreator.createUser());
+      const gpxFile = await gpxFileRepository.save(
+        EntityCreator.createGpxFile(otherUser),
+      );
+
+      const updateTour: UpdateTourDto = {
+        gpxFile: gpxFile,
+        images: [],
+        categories: [],
+      };
+
+      const response = await request(app.getHttpServer())
+        .patch(`${RoutePrefix.TOUR}/${tour.id}`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .send({ ...updateTour });
+
+      const updatedTour = await tourRepository.findOne(tour.id, {
+        relations: ['gpxFile'],
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(updatedTour.gpxFile).toEqual(null);
+    });
+
+    it('assigning a gpxFile that belongs to another tour already fails silently', async () => {
+      // Note: this test is only checked against the update route; the
+      // create route uses the same flow.
+      const tour = await tourRepository.save(
+        EntityCreator.createTour(userToCheckAgainst),
+      );
+
+      const gpxFile = await gpxFileRepository.save(
+        EntityCreator.createGpxFile(userToCheckAgainst),
+      );
+      await tourRepository.save(
+        EntityCreator.createTour(userToCheckAgainst, [], gpxFile),
+      );
+
+      const updateTour: UpdateTourDto = {
+        gpxFile: gpxFile,
+        images: [],
+        categories: [],
+      };
+
+      const response = await request(app.getHttpServer())
+        .patch(`${RoutePrefix.TOUR}/${tour.id}`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .send({ ...updateTour });
+
+      const updatedTour = await tourRepository.findOne(tour.id, {
+        relations: ['gpxFile'],
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(updatedTour.gpxFile).toEqual(null);
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/test/e2e/tour/tour-image-handling.e2e-spec.ts
+++ b/test/e2e/tour/tour-image-handling.e2e-spec.ts
@@ -1,0 +1,221 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../../../src/auth/auth.module';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import databaseConfig from '../../../src/config/database.config';
+import securityConfig from '../../../src/config/security.config';
+import environmentConfig from '../../../src/config/environment.config';
+import integrationsConfig from '../../../src/config/integrations.config';
+import mediaConfig from '../../../src/config/media.config';
+import { UserModule } from '../../../src/user/user.module';
+import { TourModule } from '../../../src/tour/tour.module';
+import { LookupModule } from '../../../src/lookup/lookup.module';
+import { MediaModule } from '../../../src/media/media.module';
+import { Repository } from 'typeorm';
+import { Tour } from '../../../src/tour/entities/tour.entity';
+import { Seeder } from '../utils/seeder';
+import { AuthService } from '../../../src/auth/auth.service';
+import { JwtService } from '@nestjs/jwt';
+import { CryptoService } from '../../../src/utils/crypto.service';
+import { UserSession } from '../../../src/auth/entities/user-session.entity';
+import { TokenDto } from '../../../src/auth/dto/auth.dto';
+import { UserRole } from '../../../src/user/entities/user.entity';
+import createLogin from '../utils/create-login';
+import { EntityCreator } from '../utils/entity-creator';
+import { CreateTourDto, UpdateTourDto } from '../../../src/tour/dto/tour.dto';
+import { faker } from '@faker-js/faker';
+import { Point } from 'geojson';
+import { Image } from '../../../src/media/entities/image.entity';
+import { RoutePrefix } from '../utils/route-prefix';
+
+const fakePoint: Point = {
+  type: 'Point',
+  coordinates: [7.920462, 47.328439],
+};
+
+describe('Tour', () => {
+  let app: INestApplication;
+  let tourRepository: Repository<Tour>;
+  let imageRepository: Repository<Image>;
+  let authService: AuthService;
+  let tokens: TokenDto;
+  const userToCheckAgainst = Seeder.getSeeds().users.find(
+    (user) => user.role === UserRole.USER,
+  );
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRootAsync({
+          imports: [
+            ConfigModule.forRoot({
+              load: [databaseConfig],
+            }),
+          ],
+          useFactory: (configService: ConfigService) =>
+            configService.get('database'),
+          inject: [ConfigService],
+        }),
+        TypeOrmModule.forFeature([UserSession]),
+        ConfigModule.forRoot({
+          load: [
+            securityConfig,
+            environmentConfig,
+            integrationsConfig,
+            mediaConfig,
+          ],
+        }),
+        AuthModule,
+        UserModule,
+        TourModule,
+        LookupModule,
+        MediaModule,
+      ],
+      providers: [AuthService, JwtService, CryptoService],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    tourRepository = moduleFixture.get('TourRepository');
+    imageRepository = moduleFixture.get('ImageRepository');
+    authService = moduleFixture.get(AuthService);
+    tokens = await createLogin(authService, userToCheckAgainst);
+
+    await app.init();
+  });
+
+  describe('Tour image handling', () => {
+    it('creating a tour assigns uploaded images sent in the create request to the tour', async () => {
+      const images = [
+        EntityCreator.createImage(userToCheckAgainst),
+        EntityCreator.createImage(userToCheckAgainst),
+      ];
+      await imageRepository.save(images);
+
+      const tour: CreateTourDto = {
+        name: faker.lorem.sentence(2),
+        description: faker.lorem.sentences(10),
+        endLocation: fakePoint,
+        startLocation: fakePoint,
+        images: images,
+        categories: [],
+        gpxFile: null,
+      };
+
+      await request(app.getHttpServer())
+        .post(`${RoutePrefix.TOUR}/`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .send({ ...tour });
+
+      const createdTour = await tourRepository.findOne({
+        name: tour.name,
+        description: tour.description,
+      });
+      const updatedImages = await imageRepository.find({
+        tourId: createdTour.id,
+      });
+
+      expect(updatedImages.length).toEqual(2);
+    });
+
+    it('updating a tour correctly synchronizes image relations', async () => {
+      const tour = await tourRepository.save(
+        EntityCreator.createTour(userToCheckAgainst),
+      );
+      const startImages = await imageRepository.save([
+        EntityCreator.createImage(userToCheckAgainst, tour),
+        EntityCreator.createImage(userToCheckAgainst, tour),
+      ]);
+
+      // We create a new image and update the tour to contain the first of the
+      // initial images and the new image, but not the second initial image
+      const newImage = await imageRepository.save(
+        EntityCreator.createImage(userToCheckAgainst),
+      );
+      const imagesToUpdate = [newImage, startImages[0]];
+      const updateTour: UpdateTourDto = {
+        images: imagesToUpdate,
+        categories: [],
+      };
+
+      await request(app.getHttpServer())
+        .patch(`${RoutePrefix.TOUR}/${tour.id}`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .send({ ...updateTour });
+
+      const updatedImages = await imageRepository.find({
+        tourId: tour.id,
+      });
+      const unassignedImage = await imageRepository.findOne(startImages[1].id);
+
+      // Tour should only contain the first of the initial images and the new
+      // image; and the second initial image should have no tour relation
+      expect(updatedImages.length).toEqual(2);
+      expect(updatedImages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: startImages[0].id,
+          }),
+        ]),
+      );
+      expect(updatedImages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: newImage.id,
+          }),
+        ]),
+      );
+      expect(updatedImages).not.toContain(unassignedImage);
+      expect(unassignedImage.tourId).toEqual(null);
+    });
+
+    it('updating a tour with an empty array removes all image relations', async () => {
+      const tour = await tourRepository.save(
+        EntityCreator.createTour(userToCheckAgainst),
+      );
+      await imageRepository.save([
+        EntityCreator.createImage(userToCheckAgainst, tour),
+        EntityCreator.createImage(userToCheckAgainst, tour),
+      ]);
+
+      const updateTour: UpdateTourDto = {
+        images: [],
+        categories: [],
+      };
+
+      await request(app.getHttpServer())
+        .patch(`${RoutePrefix.TOUR}/${tour.id}`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .send({ ...updateTour });
+
+      const updatedImages = await imageRepository.find({
+        tourId: tour.id,
+      });
+
+      expect(updatedImages.length).toEqual(0);
+    });
+
+    it('cannot assign an image that does not exist in the database', async () => {
+      const tour = await tourRepository.save(
+        EntityCreator.createTour(userToCheckAgainst),
+      );
+      const image = EntityCreator.createImage(userToCheckAgainst);
+
+      const updateTour: UpdateTourDto = {
+        images: [image],
+        categories: [],
+      };
+
+      return request(app.getHttpServer())
+        .patch(`${RoutePrefix.TOUR}/${tour.id}`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .send({ ...updateTour })
+        .expect(401);
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/test/e2e/tour/tour-management.e2e-spec.ts
+++ b/test/e2e/tour/tour-management.e2e-spec.ts
@@ -1,0 +1,166 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../../../src/auth/auth.module';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import databaseConfig from '../../../src/config/database.config';
+import securityConfig from '../../../src/config/security.config';
+import environmentConfig from '../../../src/config/environment.config';
+import integrationsConfig from '../../../src/config/integrations.config';
+import mediaConfig from '../../../src/config/media.config';
+import { UserModule } from '../../../src/user/user.module';
+import { TourModule } from '../../../src/tour/tour.module';
+import { LookupModule } from '../../../src/lookup/lookup.module';
+import { MediaModule } from '../../../src/media/media.module';
+import { Repository } from 'typeorm';
+import { Tour } from '../../../src/tour/entities/tour.entity';
+import { Seeder } from '../utils/seeder';
+import { AuthService } from '../../../src/auth/auth.service';
+import { JwtService } from '@nestjs/jwt';
+import { CryptoService } from '../../../src/utils/crypto.service';
+import { UserSession } from '../../../src/auth/entities/user-session.entity';
+import { TokenDto } from '../../../src/auth/dto/auth.dto';
+import { UserRole } from '../../../src/user/entities/user.entity';
+import createLogin from '../utils/create-login';
+import { EntityCreator } from '../utils/entity-creator';
+import { CreateTourDto, UpdateTourDto } from '../../../src/tour/dto/tour.dto';
+import { faker } from '@faker-js/faker';
+import { Point } from 'geojson';
+import { RoutePrefix } from '../utils/route-prefix';
+
+const fakePoint: Point = {
+  type: 'Point',
+  coordinates: [7.920462, 47.328439],
+};
+
+describe('Tour', () => {
+  let app: INestApplication;
+  let tourRepository: Repository<Tour>;
+  let authService: AuthService;
+  let tokens: TokenDto;
+  const userToCheckAgainst = Seeder.getSeeds().users.find(
+    (user) => user.role === UserRole.USER,
+  );
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRootAsync({
+          imports: [
+            ConfigModule.forRoot({
+              load: [databaseConfig],
+            }),
+          ],
+          useFactory: (configService: ConfigService) =>
+            configService.get('database'),
+          inject: [ConfigService],
+        }),
+        TypeOrmModule.forFeature([UserSession]),
+        ConfigModule.forRoot({
+          load: [
+            securityConfig,
+            environmentConfig,
+            integrationsConfig,
+            mediaConfig,
+          ],
+        }),
+        AuthModule,
+        UserModule,
+        TourModule,
+        LookupModule,
+        MediaModule,
+      ],
+      providers: [AuthService, JwtService, CryptoService],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    tourRepository = moduleFixture.get('TourRepository');
+    authService = moduleFixture.get(AuthService);
+    tokens = await createLogin(authService, userToCheckAgainst);
+
+    await app.init();
+  });
+
+  describe('Tour management', () => {
+    describe('create tour', () => {
+      it('a tour is created with user supplied parameters and assigned to the user', async () => {
+        const tour: CreateTourDto = {
+          name: faker.lorem.sentence(2),
+          description: faker.lorem.sentences(10),
+          endLocation: fakePoint,
+          startLocation: fakePoint,
+          images: [],
+          categories: [],
+          gpxFile: null,
+        };
+
+        await request(app.getHttpServer())
+          .post(`${RoutePrefix.TOUR}/`)
+          .set('Authorization', 'Bearer ' + tokens.accessToken)
+          .send({ ...tour });
+
+        const createdTour = await tourRepository.findOne({
+          name: tour.name,
+          description: tour.description,
+        });
+
+        expect(createdTour).toBeDefined();
+        expect(createdTour.userId).toEqual(userToCheckAgainst.id);
+      });
+    });
+
+    describe('update tour', () => {
+      it('a tour is updated with user supplied parameters', async () => {
+        const tour = await tourRepository.save(
+          EntityCreator.createTour(userToCheckAgainst),
+        );
+
+        const updateTour: UpdateTourDto = {
+          name: faker.lorem.sentence(2),
+          description: faker.lorem.sentences(10),
+          endLocation: fakePoint,
+          startLocation: fakePoint,
+          images: [],
+          categories: [],
+          gpxFile: null,
+        };
+
+        await request(app.getHttpServer())
+          .patch(`${RoutePrefix.TOUR}/${tour.id}`)
+          .set('Authorization', 'Bearer ' + tokens.accessToken)
+          .send({ ...updateTour });
+
+        const updatedTour = await tourRepository.findOne(tour.id);
+
+        expect(updatedTour.userId).toEqual(userToCheckAgainst.id);
+        expect(updatedTour.name).toEqual(updateTour.name);
+        expect(updatedTour.description).toEqual(updateTour.description);
+        expect(updatedTour.startLocation).toEqual(updateTour.startLocation);
+        expect(updatedTour.endLocation).toEqual(updateTour.endLocation);
+        expect(updatedTour.updatedAt).not.toEqual(tour.updatedAt);
+      });
+    });
+
+    describe('delete tour', () => {
+      it('a tour is deleted from the database', async () => {
+        const tour = await tourRepository.save(
+          EntityCreator.createTour(userToCheckAgainst),
+        );
+
+        const response = await request(app.getHttpServer())
+          .delete(`${RoutePrefix.TOUR}/${tour.id}`)
+          .set('Authorization', 'Bearer ' + tokens.accessToken);
+
+        const createdTour = await tourRepository.findOne(tour.id);
+
+        expect(response.statusCode).toEqual(200);
+        expect(createdTour).not.toBeDefined();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/test/e2e/tour/tour-scoping.e2e-spec.ts
+++ b/test/e2e/tour/tour-scoping.e2e-spec.ts
@@ -15,33 +15,16 @@ import { LookupModule } from '../../../src/lookup/lookup.module';
 import { MediaModule } from '../../../src/media/media.module';
 import { Repository } from 'typeorm';
 import { Tour } from '../../../src/tour/entities/tour.entity';
-import { Seeder } from '../utils/seeder';
-import {
-  StorageProvider,
-  StorageProviderInterface,
-  UploadedFileHandle,
-} from '../../../src/media/providers/types/storage-provider';
+import { StorageProviderInterface } from '../../../src/media/providers/types/storage-provider';
 import { AuthService } from '../../../src/auth/auth.service';
 import { JwtService } from '@nestjs/jwt';
 import { CryptoService } from '../../../src/utils/crypto.service';
 import { UserSession } from '../../../src/auth/entities/user-session.entity';
 import { TokenDto } from '../../../src/auth/dto/auth.dto';
-import { User, UserRole } from '../../../src/user/entities/user.entity';
+import { User } from '../../../src/user/entities/user.entity';
 import createLogin from '../utils/create-login';
 import { EntityCreator } from '../utils/entity-creator';
-import { TourDto } from '../../../src/tour/dto/tour.dto';
-
-const TOUR_ROUTE_PREFIX = '/tours';
-
-const fileResponseMock: UploadedFileHandle = {
-  identifier: 'mocked-identifier',
-  metadata: {},
-};
-
-const storageProviderMock: StorageProvider = {
-  put: jest.fn().mockReturnValue(fileResponseMock),
-  deleteMany: jest.fn(),
-};
+import { RoutePrefix } from '../utils/route-prefix';
 
 /**
  * Creates two users with one tour each and returns them and their tour. Also
@@ -109,10 +92,7 @@ describe('Tour', () => {
         MediaModule,
       ],
       providers: [AuthService, JwtService, CryptoService],
-    })
-      .overrideProvider(StorageProviderInterface)
-      .useValue(storageProviderMock)
-      .compile();
+    }).compile();
 
     app = moduleFixture.createNestApplication();
     tourRepository = moduleFixture.get('TourRepository');
@@ -131,7 +111,7 @@ describe('Tour', () => {
       );
 
       const response = await request(app.getHttpServer())
-        .get(`${TOUR_ROUTE_PREFIX}/`)
+        .get(`${RoutePrefix.TOUR}/`)
         .set('Authorization', 'Bearer ' + tokens.accessToken);
 
       expect(response.body.length).toEqual(1);
@@ -146,7 +126,7 @@ describe('Tour', () => {
       );
 
       return request(app.getHttpServer())
-        .get(`${TOUR_ROUTE_PREFIX}/${otherUserTour.id}`)
+        .get(`${RoutePrefix.TOUR}/${otherUserTour.id}`)
         .set('Authorization', 'Bearer ' + tokens.accessToken)
         .expect(404);
     });
@@ -159,7 +139,7 @@ describe('Tour', () => {
       );
 
       return request(app.getHttpServer())
-        .patch(`${TOUR_ROUTE_PREFIX}/${otherUserTour.id}`)
+        .patch(`${RoutePrefix.TOUR}/${otherUserTour.id}`)
         .set('Authorization', 'Bearer ' + tokens.accessToken)
         .send({ name: 'Changing the name', images: [], categories: [] })
         .expect(404);
@@ -173,7 +153,7 @@ describe('Tour', () => {
       );
 
       return request(app.getHttpServer())
-        .delete(`${TOUR_ROUTE_PREFIX}/${otherUserTour.id}`)
+        .delete(`${RoutePrefix.TOUR}/${otherUserTour.id}`)
         .set('Authorization', 'Bearer ' + tokens.accessToken)
         .expect(404);
     });

--- a/test/e2e/tour/tour.e2e-spec.ts
+++ b/test/e2e/tour/tour.e2e-spec.ts
@@ -1,0 +1,185 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../../../src/auth/auth.module';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import databaseConfig from '../../../src/config/database.config';
+import securityConfig from '../../../src/config/security.config';
+import environmentConfig from '../../../src/config/environment.config';
+import integrationsConfig from '../../../src/config/integrations.config';
+import mediaConfig from '../../../src/config/media.config';
+import { UserModule } from '../../../src/user/user.module';
+import { TourModule } from '../../../src/tour/tour.module';
+import { LookupModule } from '../../../src/lookup/lookup.module';
+import { MediaModule } from '../../../src/media/media.module';
+import { Repository } from 'typeorm';
+import { Tour } from '../../../src/tour/entities/tour.entity';
+import { Seeder } from '../utils/seeder';
+import {
+  StorageProvider,
+  StorageProviderInterface,
+  UploadedFileHandle,
+} from '../../../src/media/providers/types/storage-provider';
+import { AuthService } from '../../../src/auth/auth.service';
+import { JwtService } from '@nestjs/jwt';
+import { CryptoService } from '../../../src/utils/crypto.service';
+import { UserSession } from '../../../src/auth/entities/user-session.entity';
+import { TokenDto } from '../../../src/auth/dto/auth.dto';
+import { User, UserRole } from '../../../src/user/entities/user.entity';
+import createLogin from '../utils/create-login';
+import { EntityCreator } from '../utils/entity-creator';
+import { TourDto } from '../../../src/tour/dto/tour.dto';
+
+const TOUR_ROUTE_PREFIX = '/tours';
+
+const fileResponseMock: UploadedFileHandle = {
+  identifier: 'mocked-identifier',
+  metadata: {},
+};
+
+const storageProviderMock: StorageProvider = {
+  put: jest.fn().mockReturnValue(fileResponseMock),
+  deleteMany: jest.fn(),
+};
+
+/**
+ * Creates two users with one tour each and returns them and their tour. Also
+ * creates a mock login for userToCheck and returns the TokenDTO.
+ * @param userRepository
+ * @param tourRepository
+ * @param authService
+ */
+async function mockTwoUsers(
+  userRepository: Repository<User>,
+  tourRepository: Repository<Tour>,
+  authService: AuthService,
+): Promise<{
+  otherUserTour: Tour;
+  userToCheckTour: Tour;
+  tokens: TokenDto;
+  userToCheck: User;
+  otherUser: User;
+}> {
+  const userToCheck = await userRepository.save(EntityCreator.createUser());
+  const userToCheckTour = await tourRepository.save(
+    EntityCreator.createTour(userToCheck),
+  );
+  const tokens = await createLogin(authService, userToCheck);
+  const otherUser = await userRepository.save(EntityCreator.createUser());
+  const otherUserTour = await tourRepository.save(
+    EntityCreator.createTour(otherUser),
+  );
+
+  return { userToCheck, userToCheckTour, tokens, otherUser, otherUserTour };
+}
+
+describe('Tour', () => {
+  let app: INestApplication;
+  let tourRepository: Repository<Tour>;
+  let userRepository: Repository<User>;
+  let authService: AuthService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRootAsync({
+          imports: [
+            ConfigModule.forRoot({
+              load: [databaseConfig],
+            }),
+          ],
+          useFactory: (configService: ConfigService) =>
+            configService.get('database'),
+          inject: [ConfigService],
+        }),
+        TypeOrmModule.forFeature([UserSession]),
+        ConfigModule.forRoot({
+          load: [
+            securityConfig,
+            environmentConfig,
+            integrationsConfig,
+            mediaConfig,
+          ],
+        }),
+        AuthModule,
+        UserModule,
+        TourModule,
+        LookupModule,
+        MediaModule,
+      ],
+      providers: [AuthService, JwtService, CryptoService],
+    })
+      .overrideProvider(StorageProviderInterface)
+      .useValue(storageProviderMock)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    tourRepository = moduleFixture.get('TourRepository');
+    userRepository = moduleFixture.get('UserRepository');
+    authService = moduleFixture.get(AuthService);
+
+    await app.init();
+  });
+
+  describe('Tour access and management is correctly scoped to the user', () => {
+    it('/tours (GET) returns only tours of the current user', async () => {
+      const { userToCheckTour, tokens } = await mockTwoUsers(
+        userRepository,
+        tourRepository,
+        authService,
+      );
+
+      const response = await request(app.getHttpServer())
+        .get(`${TOUR_ROUTE_PREFIX}/`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken);
+
+      expect(response.body.length).toEqual(1);
+      expect(response.body[0].id).toEqual(userToCheckTour.id);
+    });
+
+    it("/tours/:id (GET) throws 404 if trying to access another user's tour", async () => {
+      const { tokens, otherUserTour } = await mockTwoUsers(
+        userRepository,
+        tourRepository,
+        authService,
+      );
+
+      return request(app.getHttpServer())
+        .get(`${TOUR_ROUTE_PREFIX}/${otherUserTour.id}`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .expect(404);
+    });
+
+    it("/tours/:id (PATCH) throws 404 if trying to update another user's tour", async () => {
+      const { tokens, otherUserTour } = await mockTwoUsers(
+        userRepository,
+        tourRepository,
+        authService,
+      );
+
+      return request(app.getHttpServer())
+        .patch(`${TOUR_ROUTE_PREFIX}/${otherUserTour.id}`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .send({ name: 'Changing the name', images: [], categories: [] })
+        .expect(404);
+    });
+
+    it("/tours/:id (DELETE) throws 404 if trying to update another user's tour", async () => {
+      const { tokens, otherUserTour } = await mockTwoUsers(
+        userRepository,
+        tourRepository,
+        authService,
+      );
+
+      return request(app.getHttpServer())
+        .delete(`${TOUR_ROUTE_PREFIX}/${otherUserTour.id}`)
+        .set('Authorization', 'Bearer ' + tokens.accessToken)
+        .expect(404);
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/test/e2e/utils/entity-creator.ts
+++ b/test/e2e/utils/entity-creator.ts
@@ -1,13 +1,15 @@
 import { User, UserRole } from '../../../src/user/entities/user.entity';
 import { Tour } from '../../../src/tour/entities/tour.entity';
+import { Image } from '../../../src/media/entities/image.entity';
+
 import { faker } from '@faker-js/faker';
 
 export class EntityCreator {
-  public static createTour(user: User): Tour {
+  public static createTour(user: User, images: Image[] = []): Tour {
     return {
       id: faker.datatype.uuid(),
       name: faker.lorem.sentence(2),
-      images: [],
+      images: images,
       createdAt: faker.date.past(),
       updatedAt: faker.date.past(),
       user: user,
@@ -17,6 +19,20 @@ export class EntityCreator {
       startLocation: null,
       gpxFile: null,
       userId: user.id,
+    };
+  }
+
+  public static createImage(user: User = null, tour: Tour = null): Image {
+    return {
+      id: faker.datatype.uuid(),
+      identifier: faker.lorem.sentence(1),
+      createdAt: faker.date.past(),
+      updatedAt: faker.date.past(),
+      user: user,
+      location: null,
+      userId: user?.id,
+      tour: tour,
+      tourId: tour?.id,
     };
   }
 

--- a/test/e2e/utils/entity-creator.ts
+++ b/test/e2e/utils/entity-creator.ts
@@ -3,9 +3,14 @@ import { Tour } from '../../../src/tour/entities/tour.entity';
 import { Image } from '../../../src/media/entities/image.entity';
 
 import { faker } from '@faker-js/faker';
+import { GpxFile } from '../../../src/media/entities/gpx-file.entity';
 
 export class EntityCreator {
-  public static createTour(user: User, images: Image[] = []): Tour {
+  public static createTour(
+    user: User,
+    images: Image[] = [],
+    gpxFile: GpxFile = null,
+  ): Tour {
     return {
       id: faker.datatype.uuid(),
       name: faker.lorem.sentence(2),
@@ -17,7 +22,7 @@ export class EntityCreator {
       description: faker.lorem.sentences(10),
       endLocation: null,
       startLocation: null,
-      gpxFile: null,
+      gpxFile: gpxFile,
       userId: user.id,
     };
   }
@@ -33,6 +38,17 @@ export class EntityCreator {
       userId: user?.id,
       tour: tour,
       tourId: tour?.id,
+    };
+  }
+
+  public static createGpxFile(user: User = null): GpxFile {
+    return {
+      id: faker.datatype.uuid(),
+      identifier: faker.lorem.sentence(1),
+      name: faker.system.commonFileName('gpx'),
+      createdAt: faker.date.past(),
+      updatedAt: faker.date.past(),
+      user: user,
     };
   }
 

--- a/test/e2e/utils/route-prefix.ts
+++ b/test/e2e/utils/route-prefix.ts
@@ -1,0 +1,7 @@
+export enum RoutePrefix {
+  AUTH = '/auth',
+  USER = '/users',
+  TOUR = '/tours',
+  LOOKUP = '/lookup',
+  MEDIA = '/media',
+}


### PR DESCRIPTION
This adds even more integration tests (#82). Currently, we test the following things:

* Route access (which verifies we have set the correct tokens)
* JWT strategies (in that they correctly verify the correct token)
* Tour: Checks whether the scoping is correct on all routes and whether media handling works correctly (scoping, assigning relations, synchronizing relations, etc.)

While doing that, I noticed a somewhat nasty bug: Previously, you could assign a media file to more than just one tour because we were not checking for existing relations in the `TourService` where we fetch the user's media files. I added this check for both image and GpxFile, which in turn had consequences for our unit tests. I had to do some nasty stuff to get them working again, but I think we do have this covered with enough tests now.

Anyway, @Saela please check whether everything still works (image upload, gpx upload, editing/creating/removing, etc.). You can see the changed code in `TourService` to see what I changed.

I also removed the `ValidateNested` check on `ImageDto`, because I introduced a regression there which broke the imageupload completely :D