### PR TITLE
Add better slugifier to not lose filenames

### DIFF
--- a/src/media/providers/google-cloud-storage/google-cloud-storage-provider.ts
+++ b/src/media/providers/google-cloud-storage/google-cloud-storage-provider.ts
@@ -8,8 +8,8 @@ import { Bucket, Storage } from '@google-cloud/storage';
 import { ConfigService } from '@nestjs/config';
 import { UploadFileDto } from '../../dto/file.dto';
 import { randomUUID } from 'crypto';
-import slugify from 'slugify';
 import { GoogleCloudStorageException } from './google-cloud-storage-provider.exceptions';
+import { slugifyFilename } from '../../utils/slugify-filename';
 
 @Injectable()
 export class GoogleCloudStorageProvider implements StorageProvider {
@@ -80,7 +80,7 @@ export class GoogleCloudStorageProvider implements StorageProvider {
    */
   private getFileName(fileName: string): string {
     const uuid = randomUUID();
-    const slugifiedFileName = slugify(fileName, { lower: true, strict: true });
+    const slugifiedFileName = slugifyFilename(fileName);
 
     return `${uuid}_${slugifiedFileName}`;
   }

--- a/src/media/utils/slugify-filename.spec.ts
+++ b/src/media/utils/slugify-filename.spec.ts
@@ -1,0 +1,27 @@
+import { slugifyFilename } from './slugify-filename';
+
+describe('slugify-filename', () => {
+  it('returns a slugified filename with its extension', () => {
+    const filename = 'testFileöäü.jpg';
+
+    const slugified = slugifyFilename(filename);
+
+    expect(slugified).toEqual('testfileoau.jpg');
+  });
+
+  it('returns a slugified filename with its extension if it has multiple dots', () => {
+    const filename = 'testFileöäü.copy.test.jpg';
+
+    const slugified = slugifyFilename(filename);
+
+    expect(slugified).toEqual('testfileoaucopytest.jpg');
+  });
+
+  it('returns a slugified filename if it has no extension', () => {
+    const filename = 'testFileöäü';
+
+    const slugified = slugifyFilename(filename);
+
+    expect(slugified).toEqual('testfileoau');
+  });
+});

--- a/src/media/utils/slugify-filename.ts
+++ b/src/media/utils/slugify-filename.ts
@@ -1,0 +1,28 @@
+import slugify from 'slugify';
+
+const slugifyOptions = { lower: true, strict: true };
+/**
+ * Returns a slugified filename. If it has an extension, it slugifies only the
+ * actual filename and appends the extension; if not, it slugifies the whole
+ * filename.
+ *
+ * Note that we treat the last element after a dot as extension - this does not
+ * have to mean that it is a valid extension. E.g. "filename.wrongextension"
+ * will be slugified to "filename.wrongextension" because that's what we assume
+ * is the file extension.
+ *
+ * @param filename
+ */
+export function slugifyFilename(filename: string) {
+  const splitFilename = filename.split('.');
+
+  if (splitFilename.length === 1) {
+    return slugify(filename, slugifyOptions);
+  } else {
+    const extension = splitFilename.pop();
+
+    const slugifiedFilename = slugify(splitFilename.join(), slugifyOptions);
+
+    return `${slugifiedFilename}.${extension}`;
+  }
+}


### PR DESCRIPTION
Closes #100 

@Saela It was actually a backend issue. We now retain the extension (if there is one) which also handles the frontend download: Because we're having an extension, it works :)