### PR TITLE
Fix bad reliance on repository in auth guard

### DIFF
--- a/jest-e2e.json
+++ b/jest-e2e.json
@@ -1,11 +1,12 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
+  "testPathIgnorePatterns": ["../dist/"],
   "rootDir": "./src",
   "roots": ["../test"],
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
+    "^.+\\.(t)s$": "ts-jest"
   },
   "testTimeout": 20000,
   "setupFiles": [

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { LocalStrategy } from './strategies/local.strategy';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { PassportModule } from '@nestjs/passport';
@@ -21,7 +21,7 @@ import { TokenBearerAuthGuard } from './guards/token-bearer-auth.guard';
 @Module({
   imports: [
     TypeOrmModule.forFeature([UserSession]),
-    UserModule,
+    forwardRef(() => UserModule),
     UtilsModule,
     PassportModule,
     NotificationModule,

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -17,6 +17,7 @@ import { RefreshedToken, UserIdentifier } from './types/auth';
 import * as dayjs from 'dayjs';
 import { ConfigService } from '@nestjs/config';
 import { randomUUID } from 'crypto';
+import { UserAuthService } from '../user/user-auth.service';
 
 const defaultRefreshTokenValidity = 1000;
 const defaultToken = 'insecure-jwt-token-used-for-testing-only';
@@ -52,6 +53,7 @@ describe('AuthService', () => {
   let authService: AuthService;
   let userService: UserService;
   let sessionRepositoryMock: RepositoryMockType<Repository<UserSession>>;
+  let userAuthService: UserAuthService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -65,6 +67,7 @@ describe('AuthService', () => {
         AuthService,
         UserService,
         CryptoService,
+        UserAuthService,
         {
           provide: getRepositoryToken(User),
           useFactory: repositoryMockFactory,
@@ -93,6 +96,7 @@ describe('AuthService', () => {
 
     authService = module.get<AuthService>(AuthService);
     userService = module.get<UserService>(UserService);
+    userAuthService = module.get<UserAuthService>(UserAuthService);
     sessionRepositoryMock = module.get(getRepositoryToken(UserSession));
   });
 
@@ -207,6 +211,18 @@ describe('AuthService', () => {
       expect(sessionRepositoryMock.delete).toHaveBeenCalledTimes(1);
       expect(sessionRepositoryMock.delete).toHaveBeenCalledWith(mockSession);
       expect(result).toEqual(undefined);
+    });
+  });
+  describe('isUserAdministrator', () => {
+    it('calls userAuthService with the correct parameter', async () => {
+      const mockEmail = 'test@gipfeli.io';
+      const serviceSpy = jest
+        .spyOn(userAuthService, 'isUserAdministrator')
+        .mockResolvedValue(true);
+
+      await authService.isUserAdministrator(mockEmail);
+
+      expect(serviceSpy).toHaveBeenCalledWith(mockEmail);
     });
   });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -10,6 +10,7 @@ import * as dayjs from 'dayjs';
 import { RefreshedToken, UserIdentifier } from './types/auth';
 import { ConfigService } from '@nestjs/config';
 import { UserRole } from '../user/entities/user.entity';
+import { UserAuthService } from '../user/user-auth.service';
 
 @Injectable()
 export class AuthService {
@@ -19,6 +20,7 @@ export class AuthService {
   constructor(
     private readonly configService: ConfigService,
     private readonly userService: UserService,
+    private readonly userAuthService: UserAuthService,
     private readonly jwtService: JwtService,
     private readonly hashService: CryptoService,
     @InjectRepository(UserSession)
@@ -117,6 +119,10 @@ export class AuthService {
     // Since we do not care if invalid session ids are sent, we just fire and
     // forget the delete request.
     await this.sessionRepository.delete(sessionId);
+  }
+
+  async isUserAdministrator(email: string): Promise<boolean> {
+    return this.userAuthService.isUserAdministrator(email);
   }
 
   /**

--- a/src/auth/guards/admin.guard.ts
+++ b/src/auth/guards/admin.guard.ts
@@ -1,6 +1,6 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { UserRole } from '../../user/entities/user.entity';
-import { UserAuthService } from '../../user/user-auth.service';
+import { AuthService } from '../auth.service';
 
 /**
  * This guard ensures only users with role === UserRole.ADMINISTRATOR may access
@@ -10,7 +10,7 @@ import { UserAuthService } from '../../user/user-auth.service';
  */
 @Injectable()
 export class AdminGuard implements CanActivate {
-  constructor(private readonly userAuthService: UserAuthService) {}
+  constructor(private readonly authService: AuthService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
@@ -24,6 +24,6 @@ export class AdminGuard implements CanActivate {
       return false;
     }
 
-    return this.userAuthService.isUserAdministrator(user.email);
+    return this.authService.isUserAdministrator(user.email);
   }
 }

--- a/src/user/user-auth.service.spec.ts
+++ b/src/user/user-auth.service.spec.ts
@@ -268,4 +268,31 @@ describe('UserAuthService', () => {
       await expect(result).rejects.toThrow(BadRequestException);
     });
   });
+  describe('isUserAdministrator', () => {
+    it('returns true if the user is an administrator', async () => {
+      const mockEmail = 'test@gipfeli.io';
+      userRepositoryMock.findOneOrFail.mockReturnValue(true);
+
+      const result = await userAuthService.isUserAdministrator(mockEmail);
+
+      expect(result).toEqual(true);
+      expect(userRepositoryMock.findOneOrFail).toHaveBeenCalledWith({
+        where: [{ email: mockEmail, role: UserRole.ADMINISTRATOR }],
+      });
+    });
+
+    it('returns false if the user is not an administrator or does not exist', async () => {
+      const mockEmail = 'test@gipfeli.io';
+      jest.spyOn(userRepositoryMock, 'findOneOrFail').mockImplementation(() => {
+        throw new Error(); // mock an error in the db query as failure
+      });
+
+      const result = await userAuthService.isUserAdministrator(mockEmail);
+
+      expect(result).toEqual(false);
+      expect(userRepositoryMock.findOneOrFail).toHaveBeenCalledWith({
+        where: [{ email: mockEmail, role: UserRole.ADMINISTRATOR }],
+      });
+    });
+  });
 });

--- a/src/user/user-auth.service.ts
+++ b/src/user/user-auth.service.ts
@@ -4,7 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { User } from './entities/user.entity';
+import { User, UserRole } from './entities/user.entity';
 import { EntityNotFoundError, Repository } from 'typeorm';
 import { ActivateUserDto } from './dto/user.dto';
 import { CryptoService } from '../utils/crypto.service';
@@ -116,6 +116,26 @@ export class UserAuthService {
     }
     // The tokens do not match
     throw new BadRequestException();
+  }
+
+  /**
+   * Checks whether a supplied email address matches a user that is an
+   * administrator. This can be used to ensure that the supplied token's role is
+   * still mirrored in the DB. If an access token signals that a user is an
+   * administrator, it might be that in the meantime, their admin rights have
+   * been revoked. In this case, this method will return false.
+   *
+   * @param email
+   */
+  async isUserAdministrator(email: string): Promise<boolean> {
+    try {
+      await this.userRepository.findOneOrFail({
+        where: [{ email, role: UserRole.ADMINISTRATOR }],
+      });
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 
   /**

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -9,6 +9,9 @@ import { UserToken } from './entities/user-token.entity';
 import { CryptoService } from '../utils/crypto.service';
 import { ConfigService } from '@nestjs/config';
 import { UserAuthService } from './user-auth.service';
+import { AuthService } from '../auth/auth.service';
+import { JwtModule } from '@nestjs/jwt';
+import { UserSession } from '../auth/entities/user-session.entity';
 
 const results: UserDto[] = [
   {
@@ -33,11 +36,18 @@ describe('UserController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        JwtModule.register({
+          secret: 'x-x-x',
+          signOptions: { expiresIn: '3600s' },
+        }),
+      ],
       controllers: [UserController],
       providers: [
         UserService,
         CryptoService,
         ConfigService,
+        AuthService,
         UserAuthService,
         {
           provide: getRepositoryToken(User),
@@ -45,6 +55,10 @@ describe('UserController', () => {
         },
         {
           provide: getRepositoryToken(UserToken),
+          useFactory: repositoryMockFactory,
+        },
+        {
+          provide: getRepositoryToken(UserSession),
           useFactory: repositoryMockFactory,
         },
       ],

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -8,6 +8,7 @@ import repositoryMockFactory from '../utils/mock-utils/repository-mock.factory';
 import { UserToken } from './entities/user-token.entity';
 import { CryptoService } from '../utils/crypto.service';
 import { ConfigService } from '@nestjs/config';
+import { UserAuthService } from './user-auth.service';
 
 const results: UserDto[] = [
   {
@@ -37,6 +38,7 @@ describe('UserController', () => {
         UserService,
         CryptoService,
         ConfigService,
+        UserAuthService,
         {
           provide: getRepositoryToken(User),
           useFactory: repositoryMockFactory,

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { UserService } from './user.service';
@@ -6,9 +6,14 @@ import { UserController } from './user.controller';
 import { UtilsModule } from '../utils/utils.module';
 import { UserToken } from './entities/user-token.entity';
 import { UserAuthService } from './user-auth.service';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, UserToken]), UtilsModule],
+  imports: [
+    TypeOrmModule.forFeature([User, UserToken]),
+    UtilsModule,
+    forwardRef(() => AuthModule),
+  ],
   providers: [UserService, UserAuthService],
   controllers: [UserController],
   exports: [UserService, UserAuthService],

--- a/test/e2e/route-access/admin.e2e-spec.ts
+++ b/test/e2e/route-access/admin.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
+import { forwardRef, INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -36,6 +36,7 @@ describe('Admin Routes can be accessed by an admin user', () => {
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
+        forwardRef(() => AuthModule),
         TypeOrmModule.forRootAsync({
           imports: [
             ConfigModule.forRoot({


### PR DESCRIPTION
This PR fixes the fact that our `AdminGuard` was directly injecting the `UserRepository` which does not work well with our separation. Now it relies on `UserService` which handles the check whether a user is an administrator or not. I also hardcoded the role, because it does not make sense to supply it (we should ONLY check whether it is an administrator).

I also fixed an issue with jest that logged JS compilation errors when having a build directory.

**Edit:** Actually, it was even wrong with UserService. Now, only the `AuthService` relies on other services, so our guards do not rely on external repositories or services.

**Edit2:** We need to use `forwardRef` to avoid the circular dependency :)